### PR TITLE
Free previously allocate PPS and ref_pic_sets.

### DIFF
--- a/libde265/decctx.c
+++ b/libde265/decctx.c
@@ -193,6 +193,7 @@ void process_sps(decoder_context* ctx, seq_parameter_set* sps)
 
 void process_pps(decoder_context* ctx, pic_parameter_set* pps)
 {
+  free_pps(&ctx->pps[ (int)pps->pic_parameter_set_id ]);
   memcpy(&ctx->pps[ (int)pps->pic_parameter_set_id ], pps, sizeof(pic_parameter_set));
 }
 

--- a/libde265/sps.c
+++ b/libde265/sps.c
@@ -162,6 +162,8 @@ de265_error read_sps(bitreader* br, seq_parameter_set* sps, ref_pic_set** ref_pi
   // --- allocate reference pic set ---
 
   // allocate one more for the ref-pic-set that may be sent in the slice header
+  // TODO: should use "realloc" and only reallocate if necessary
+  free(*ref_pic_sets);
   *ref_pic_sets = (ref_pic_set *)calloc(sizeof(ref_pic_set), sps->num_short_term_ref_pic_sets + 1);
 
   for (int i = 0; i < sps->num_short_term_ref_pic_sets; i++) {


### PR DESCRIPTION
This fixes a memory leak if a stream contains multiple PPS and SPS.
