### PR TITLE
Prefix "DECLARE_ALIGNED" to avoid conflict with definition in ffmpeg.

### DIFF
--- a/libde265/de265.h
+++ b/libde265/de265.h
@@ -42,14 +42,14 @@ extern "C" {
 #endif
 
 #ifdef _MSC_VER
-#define DECLARE_ALIGNED( var, n ) __declspec(align(n)) var
+#define LIBDE265_DECLARE_ALIGNED( var, n ) __declspec(align(n)) var
 #else
-#define DECLARE_ALIGNED( var, n ) var __attribute__((aligned(n)))
+#define LIBDE265_DECLARE_ALIGNED( var, n ) var __attribute__((aligned(n)))
 #endif
-#define ALIGNED_32( var ) DECLARE_ALIGNED( var, 32 )
-#define ALIGNED_16( var ) DECLARE_ALIGNED( var, 16 )
-#define ALIGNED_8( var )  DECLARE_ALIGNED( var, 8 )
-#define ALIGNED_4( var )  DECLARE_ALIGNED( var, 4 )
+#define ALIGNED_32( var ) LIBDE265_DECLARE_ALIGNED( var, 32 )
+#define ALIGNED_16( var ) LIBDE265_DECLARE_ALIGNED( var, 16 )
+#define ALIGNED_8( var )  LIBDE265_DECLARE_ALIGNED( var, 8 )
+#define ALIGNED_4( var )  LIBDE265_DECLARE_ALIGNED( var, 4 )
 
 /* === error codes === */
 

--- a/libde265/slice.h
+++ b/libde265/slice.h
@@ -152,7 +152,6 @@ typedef struct thread_context
 
   // residual data
 
-  //#define DECLARE_ALIGNED(a,t,name) t __attribute__ ((aligned (a))) name
   ALIGNED_16(int16_t) coeffBuf[32*32]; // alignment required for SSE code !
 
   int16_t coeffList[3][32*32];


### PR DESCRIPTION
If you include "de265.h" from a module inside ffmpeg, you get a warning about a duplicate definition.
