### PR TITLE
Avoid excessive reallocations for skipped bytes.

### DIFF
--- a/libde265/de265.c
+++ b/libde265/de265.c
@@ -183,21 +183,18 @@ static de265_error process_data(decoder_context* ctx, const uint8_t* data, int l
         *out++ = 0; *out++ = 0; ctx->input_push_state=5;
 
         // remember which byte we removed
+        if (ctx->max_skipped_bytes == ctx->num_skipped_bytes) {
+            if (ctx->max_skipped_bytes == 0) {
+              ctx->max_skipped_bytes = 32;
+            } else {
+              ctx->max_skipped_bytes <<= 2;
+            }
 
-        int* skipped = (int *)malloc((ctx->num_skipped_bytes+1) * sizeof(int));
-
-        if (ctx->num_skipped_bytes>0) {
-          memcpy(skipped, ctx->skipped_bytes, ctx->num_skipped_bytes * sizeof(int));
+            // TODO: handle case where realloc fails
+            ctx->skipped_bytes = (int *)realloc(ctx->skipped_bytes, ctx->max_skipped_bytes * sizeof(int));
         }
 
-        if (ctx->skipped_bytes) {
-          free(ctx->skipped_bytes);
-        }
-
-        skipped[ctx->num_skipped_bytes] = (out - ctx->nal_data.data) + ctx->num_skipped_bytes;
-
-        ctx->skipped_bytes = skipped;
-
+        ctx->skipped_bytes[ctx->num_skipped_bytes] = (out - ctx->nal_data.data) + ctx->num_skipped_bytes;
         ctx->num_skipped_bytes++;
       }
       else if (*data==1) {

--- a/libde265/decctx.c
+++ b/libde265/decctx.c
@@ -64,6 +64,7 @@ void init_decoder_context(decoder_context* ctx)
 
   ctx->skipped_bytes = NULL;
   ctx->num_skipped_bytes = 0;
+  ctx->max_skipped_bytes = 0;
 
   rbsp_buffer_init(&ctx->nal_data);
   ctx->input_push_state = 0;

--- a/libde265/decctx.h
+++ b/libde265/decctx.h
@@ -149,6 +149,7 @@ typedef struct decoder_context {
 
   int*  skipped_bytes;  // up to position[x], there were 'x' skipped bytes
   int   num_skipped_bytes;
+  int   max_skipped_bytes;
 
   video_parameter_set  vps[ DE265_MAX_VPS_SETS ];
   seq_parameter_set    sps[ DE265_MAX_SPS_SETS ];


### PR DESCRIPTION
Reallocations are especially slow on Windows.
