### PR TITLE
Export "de265_disable_logging" as it is used by dec265.

### DIFF
--- a/libde265/de265.h
+++ b/libde265/de265.h
@@ -88,6 +88,8 @@ typedef enum {
 
 LIBDE265_API const char* de265_get_error_text(de265_error err);
 
+LIBDE265_API void de265_disable_logging();
+
 
 /* === image === */
 

--- a/libde265/util.c
+++ b/libde265/util.c
@@ -19,6 +19,7 @@
  */
 
 #include "util.h"
+#include "de265.h"
 
 #include <stdarg.h>
 #include <stdio.h>
@@ -64,7 +65,7 @@ void log_set_current_POC(int poc) { current_poc=poc; }
 
 static int disable_logging=0;
 
-void de265_disable_logging()
+LIBDE265_API void de265_disable_logging()
 {
   disable_logging=1;
 }

--- a/libde265/util.h
+++ b/libde265/util.h
@@ -72,8 +72,6 @@ enum LogModule {
 };
 
 
-void de265_disable_logging();
-
 #if defined(DE265_LOG_ERROR) || defined(DE265_LOG_INFO) || defined(DE265_LOG_DEBUG) || defined(DE265_LOG_TRACE)
 # define DE265_LOGGING 1
 void enablelog();


### PR DESCRIPTION
The function must be explicitly exported to make linking against DLL work on Windows.
