### PR TITLE
Fixes for OSX

### DIFF
--- a/libde265/image.c
+++ b/libde265/image.c
@@ -29,6 +29,15 @@
 #elif _WIN32
 #define ALLOC_ALIGNED(alignment, size)         _aligned_malloc((size), (alignment))
 #define FREE_ALIGNED(mem)                      _aligned_free((mem))
+#elif __APPLE__
+static inline void *ALLOC_ALIGNED(size_t alignment, size_t size) {
+    void *mem = NULL;
+    if (posix_memalign(&mem, alignment, size) != 0) {
+        return NULL;
+    }
+    return mem;
+};
+#define FREE_ALIGNED(mem)                      free((mem))
 #else
 #define ALLOC_ALIGNED(alignment, size)      memalign((alignment), (size))
 #define FREE_ALIGNED(mem)                   free((mem))


### PR DESCRIPTION
Fix some compilation problems on OSX:
- "malloc.h" is not available
- "memalign" is not available (but "posix_memalign")
