### PR TITLE
Allow writing YUV image in quiet mode.

### DIFF
--- a/dec265/dec265.cc
+++ b/dec265/dec265.cc
@@ -196,10 +196,9 @@ bool output_image(const de265_image* img)
 #elif HAVE_VIDEOGFX
     display_image(img);
 #endif
-
-    if (write_yuv) {
-      write_picture(img);
-    }
+  }
+  if (write_yuv) {
+    write_picture(img);
   }
 
   if ((framecnt%100)==0) {


### PR DESCRIPTION
If you are only interested in the YUV file, there is no need for the graphics output, so the quiet mode can be used.
