### PR TITLE
Update struct member alignment if necessary.

### DIFF
--- a/libde265/de265.c
+++ b/libde265/de265.c
@@ -557,7 +557,7 @@ LIBDE265_API de265_error de265_flush_data(de265_decoder_context* de265ctx)
 void init_thread_context(thread_context* tctx)
 {
   // zero scrap memory for coefficient blocks
-  memset(tctx->coeffBuf, 0, sizeof(tctx->coeffBuf));
+  memset(tctx->_coeffBuf, 0, sizeof(tctx->_coeffBuf));
 
   tctx->currentQG_x = -1;
   tctx->currentQG_y = -1;

--- a/libde265/decctx.c
+++ b/libde265/decctx.c
@@ -82,6 +82,16 @@ void init_decoder_context(decoder_context* ctx)
   // --- decoded picture buffer ---
 
   ctx->current_image_poc_lsb = -1; // any invalid number
+
+  for (int i=0;i<MAX_THREAD_CONTEXTS;i++) {
+    ctx->thread_context[i].coeffBuf = (int16_t *) &ctx->thread_context[i]._coeffBuf;
+    // some compilers/linkers don't align struct members correctly,
+    // adjust if necessary
+    int offset = (uintptr_t) ctx->thread_context[i].coeffBuf & 0x0f;
+    if (offset != 0) {
+        ctx->thread_context[i].coeffBuf = (int16_t *) (((uint8_t *)ctx->thread_context[i].coeffBuf) + (16-offset));
+    }
+  }
 }
 
 

--- a/libde265/decctx.h
+++ b/libde265/decctx.h
@@ -111,7 +111,8 @@ typedef struct thread_context
   uint8_t cu_transquant_bypass_flag;
   uint8_t transform_skip_flag[3];
 
-  ALIGNED_16(int16_t) coeffBuf[32*32]; // alignment required for SSE code !
+  ALIGNED_16(int16_t) _coeffBuf[(32*32)+8]; // alignment required for SSE code !
+  int16_t *coeffBuf;
 
   int16_t coeffList[3][32*32];
   int16_t coeffPos[3][32*32];


### PR DESCRIPTION
Some compilers/linkers (found with gcc from NativeClient) don't align properly, so this might need to be adjusted.
