### PR TITLE
C++ win32 fixes

### DIFF
--- a/dec265/Makefile.vc7
+++ b/dec265/Makefile.vc7
@@ -6,7 +6,7 @@ CC=cl /nologo
 LINK=link /nologo /subsystem:console
 DEFINES=/DWIN32
 
-CFLAGS=$(CFLAGS) /MT /Ob2 /Oi /W4
+CFLAGS=$(CFLAGS) /MT /Ob2 /Oi /W4 /EHsc
 CFLAGS=$(CFLAGS) $(DEFINES)
 
 OBJS=\
@@ -21,6 +21,9 @@ dec265.obj: dec265.cc
 
 .c.obj:
 	$(CC) /c $*.c /Fo$*.obj $(CFLAGS)
+
+.cc.obj:
+	$(CC) /c $*.cc /Fo$*.obj $(CFLAGS)
 
 dec265.exe: $(OBJS) ..\libde265\libde265.lib
 	$(LINK) /out:dec265.exe $** ..\libde265\libde265.lib

--- a/libde265/Makefile.vc7
+++ b/libde265/Makefile.vc7
@@ -6,7 +6,7 @@ CC=cl /nologo
 LINK=link /nologo /subsystem:console
 DEFINES=/DWIN32 /D_WIN32_WINNT=0x0400 /DNDEBUG /DLIBDE265_EXPORTS /D_CRT_SECURE_NO_WARNINGS /DHAVE_SSE4_1
 
-CFLAGS=$(CFLAGS) /MT /Ox /Ob2 /Oi /TP /W4 /GL
+CFLAGS=$(CFLAGS) /MT /Ox /Ob2 /Oi /TP /W4 /GL /EHsc
 
 # type conversion, possible loss of data
 CFLAGS=$(CFLAGS) /wd4244
@@ -16,6 +16,8 @@ CFLAGS=$(CFLAGS) /wd4100
 CFLAGS=$(CFLAGS) /wd4189
 # unreferenced local function has been removed
 CFLAGS=$(CFLAGS) /wd4505
+# padded structures
+CFLAGS=$(CFLAGS) /wd4324
 
 CFLAGS=$(CFLAGS) $(DEFINES)
 
@@ -34,6 +36,7 @@ OBJS=\
 	md5.obj \
 	motion.obj \
 	nal.obj \
+	nal-parser.obj \
 	pps.obj \
 	refpic.obj \
 	sao.obj \
@@ -54,6 +57,9 @@ all: libde265.dll
 
 .c.obj:
 	$(CC) /c $*.c /Fo$*.obj $(CFLAGS)
+
+.cc.obj:
+	$(CC) /c $*.cc /Fo$*.obj $(CFLAGS)
 
 libde265.dll: $(OBJS)
 	$(LINK) /dll /out:libde265.dll $**


### PR DESCRIPTION
A couple of fixes to make the C++ code compile on Windows using the Visual Studio compiler.
