### PR TITLE
Specify private libraries required for static linking.

### DIFF
--- a/libde265.pc.in
+++ b/libde265.pc.in
@@ -9,4 +9,5 @@ URL: https://github.com/strukturag/libde265
 Version: @VERSION@
 Requires: 
 Libs: -lde265 -L@libdir@
+Libs.private: @LIBS@ -lstdc++
 Cflags: -I@includedir@


### PR DESCRIPTION
Otherwise there will be lots of error like the following

```
...
/home/.../libde265.a(libde265_la-de265.o): In function `de265_new_decoder':
/home/.../libde265/libde265/de265.cc:181: undefined reference to `__gxx_personality_sj0'
/home/.../libde265/libde265/de265.cc:187: undefined reference to `operator new(unsigned int)'
/home/.../libde265/libde265/de265.cc:187: undefined reference to `operator delete(void*)'
...
```
