### PR TITLE
Sanitize use of `class` / `struct`.

### DIFF
--- a/libde265/deblock.cc
+++ b/libde265/deblock.cc
@@ -935,7 +935,7 @@ void add_deblocking_tasks(image_unit* imgunit)
           task->vertical = (pass==0);
 
           imgunit->tasks.push_back(task);
-          add_task(&ctx->thread_pool, task);
+          add_task(&ctx->thread_pool_, task);
           n++;
         }
     }

--- a/libde265/decctx.cc
+++ b/libde265/decctx.cc
@@ -324,7 +324,7 @@ void decoder_context::set_image_allocation_functions(de265_image_allocation* all
 
 de265_error decoder_context::start_thread_pool(int nThreads)
 {
-  ::start_thread_pool(&thread_pool, nThreads);
+  ::start_thread_pool(&thread_pool_, nThreads);
 
   num_worker_threads = nThreads;
 
@@ -336,7 +336,7 @@ void decoder_context::stop_thread_pool()
 {
   if (get_num_worker_threads()>0) {
     //flush_thread_pool(&ctx->thread_pool);
-    ::stop_thread_pool(&thread_pool);
+    ::stop_thread_pool(&thread_pool_);
   }
 }
 
@@ -345,7 +345,7 @@ void decoder_context::reset()
 {
   if (num_worker_threads>0) {
     //flush_thread_pool(&ctx->thread_pool);
-    ::stop_thread_pool(&thread_pool);
+    ::stop_thread_pool(&thread_pool_);
   }
 
   // --------------------------------------------------
@@ -477,7 +477,7 @@ void decoder_context::add_task_decode_CTB_row(thread_context* tctx, bool firstSl
   task->tctx = tctx;
   tctx->task = task;
 
-  add_task(&thread_pool, task);
+  add_task(&thread_pool_, task);
 
   tctx->imgunit->tasks.push_back(task);
 }
@@ -490,7 +490,7 @@ void decoder_context::add_task_decode_slice_segment(thread_context* tctx, bool f
   task->tctx = tctx;
   tctx->task = task;
 
-  add_task(&thread_pool, task);
+  add_task(&thread_pool_, task);
 
   tctx->imgunit->tasks.push_back(task);
 }
@@ -773,8 +773,7 @@ de265_error decoder_context::decode_slice_unit_sequential(image_unit* imgunit,
   remove_images_from_dpb(sliceunit->shdr->RemoveReferencesList);
 
 
-  struct thread_context tctx;
-
+  thread_context tctx;
   tctx.shdr = sliceunit->shdr;
   tctx.img  = imgunit->img;
   tctx.decctx = this;

--- a/libde265/decctx.h
+++ b/libde265/decctx.h
@@ -42,12 +42,14 @@
 #define MAX_WARNINGS 20
 
 
-struct slice_segment_header;
-struct image_unit;
+class slice_segment_header;
+class image_unit;
+class decoder_context;
 
 
-struct thread_context
+class thread_context
 {
+public:
   thread_context();
 
   int CtbAddrInRS;
@@ -94,12 +96,12 @@ struct thread_context
 
   context_model ctx_model[CONTEXT_MODEL_TABLE_LENGTH];
 
-  struct decoder_context* decctx;
+  decoder_context* decctx;
   struct de265_image *img;
-  struct slice_segment_header* shdr;
+  slice_segment_header* shdr;
 
-  struct image_unit* imgunit;
-  struct thread_task* task; // executing thread_task or NULL if not multi-threaded
+  image_unit* imgunit;
+  thread_task* task; // executing thread_task or NULL if not multi-threaded
 
 private:
   thread_context(const thread_context&); // not allowed
@@ -125,8 +127,9 @@ class error_queue
 
 
 
-struct slice_unit
+class slice_unit
 {
+public:
   slice_unit(decoder_context* decctx);
   ~slice_unit();
 
@@ -134,7 +137,7 @@ struct slice_unit
   slice_segment_header* shdr;  // not the owner (de265_image is owner)
   bitreader reader;
 
-  struct image_unit* imgunit;
+  image_unit* imgunit;
 
   bool flush_reorder_buffer;
 
@@ -158,8 +161,9 @@ private:
 };
 
 
-struct image_unit
+class image_unit
 {
+public:
   image_unit();
   ~image_unit();
 
@@ -312,7 +316,7 @@ class decoder_context : public base_context {
   pic_parameter_set*   current_pps;
 
  public:
-  struct thread_pool thread_pool;
+  thread_pool thread_pool_;
 
  private:
   int num_worker_threads;
@@ -418,7 +422,7 @@ class decoder_context : public base_context {
   bool flush_reorder_buffer_at_this_frame;
 
  private:
-  void init_thread_context(class thread_context* tctx);
+  void init_thread_context(thread_context* tctx);
   void add_task_decode_CTB_row(thread_context* tctx, bool firstSliceSubstream);
   void add_task_decode_slice_segment(thread_context* tctx, bool firstSliceSubstream);
 
@@ -431,7 +435,7 @@ class decoder_context : public base_context {
 
 
   void remove_images_from_dpb(const std::vector<int>& removeImageList);
-  void run_postprocessing_filters_sequential(de265_image* img);
+  void run_postprocessing_filters_sequential(struct de265_image* img);
   void run_postprocessing_filters_parallel(image_unit* img);
 };
 

--- a/libde265/dpb.h
+++ b/libde265/dpb.h
@@ -27,9 +27,10 @@
 #include <deque>
 #include <vector>
 
+class decoder_context;
 
-
-struct decoded_picture_buffer {
+class decoded_picture_buffer {
+public:
   decoded_picture_buffer();
   ~decoded_picture_buffer();
 
@@ -52,8 +53,8 @@ struct decoded_picture_buffer {
   int size() const { return dpb.size(); }
 
   /* Raw access to the images. */
-  /* */ de265_image* get_image(int index)       { return dpb[index]; }
-  const de265_image* get_image(int index) const { return dpb[index]; }
+  /* */ struct de265_image* get_image(int index)       { return dpb[index]; }
+  const struct de265_image* get_image(int index) const { return dpb[index]; }
 
   /* Search DPB for the slot index of a specific picture. */
   int DPB_index_of_picture_with_POC(int poc, int currentID, bool preferLongTerm=false) const;
@@ -63,7 +64,7 @@ struct decoded_picture_buffer {
 
   // --- reorder buffer ---
 
-  void insert_image_into_reorder_buffer(de265_image* img) {
+  void insert_image_into_reorder_buffer(struct de265_image* img) {
     reorder_output_queue.push_back(img);
   }
 
@@ -81,7 +82,7 @@ struct decoded_picture_buffer {
   int num_pictures_in_output_queue() const { return image_output_queue.size(); }
 
   /* Get the next picture in the output queue, but do not remove it from the queue. */
-  de265_image* get_next_picture_in_output_queue() const { return image_output_queue.front(); }
+  struct de265_image* get_next_picture_in_output_queue() const { return image_output_queue.front(); }
 
   /* Remove the next picture in the output queue. */
   void pop_next_picture_in_output_queue();
@@ -96,10 +97,10 @@ private:
   int max_images_in_DPB;
   int norm_images_in_DPB;
 
-  std::vector<de265_image*> dpb; // decoded picture buffer
+  std::vector<struct de265_image*> dpb; // decoded picture buffer
 
-  std::vector<de265_image*> reorder_output_queue;
-  std::deque<de265_image*>  image_output_queue;
+  std::vector<struct de265_image*> reorder_output_queue;
+  std::deque<struct de265_image*>  image_output_queue;
 
 private:
   decoded_picture_buffer(const decoded_picture_buffer&); // no copy

--- a/libde265/encoder/encode.h
+++ b/libde265/encoder/encode.h
@@ -28,8 +28,8 @@
 #include "libde265/image-io.h"
 #include "libde265/alloc_pool.h"
 
-struct encoder_context;
-struct enc_cb;
+class encoder_context;
+class enc_cb;
 
 
 class enc_node
@@ -190,8 +190,6 @@ inline int childY(int y0, int idx, int log2CbSize)
 }
 
 
-
-struct encoder_context;
 
 void encode_transform_tree(encoder_context* ectx, const enc_tb* tb, const enc_cb* cb,
                            int x0,int y0, int xBase,int yBase,

--- a/libde265/image.h
+++ b/libde265/image.h
@@ -78,6 +78,8 @@ enum PictureState {
 #define CTB_PROGRESS_DEBLK_H   3
 #define CTB_PROGRESS_SAO       4
 
+class decoder_context;
+
 template <class DataUnit> class MetaDataArray
 {
  public:

--- a/libde265/motion.h
+++ b/libde265/motion.h
@@ -23,6 +23,10 @@
 
 #include <stdint.h>
 
+class base_context;
+class decoder_context;
+class thread_context;
+class slice_segment_header;
 
 typedef struct
 {
@@ -56,27 +60,26 @@ typedef struct
 } SpatialMergingCandidates;
 
 
-struct motion_spec {
+typedef struct {
   int8_t  refIdx[2];
   int16_t mvd[2][2]; // [L0/L1][x/y]  (only in top left position - ???)
   uint8_t merge_flag;
   uint8_t merge_idx;
   uint8_t mvp_lX_flag[2];
   uint8_t inter_pred_idc; // enum InterPredIdc
-};
+} motion_spec;
 
 
-
-void derive_spatial_merging_candidates(const class de265_image* img,
+void derive_spatial_merging_candidates(const struct de265_image* img,
                                        int xC, int yC, int nCS, int xP, int yP,
                                        uint8_t singleMCLFlag,
                                        int nPbW, int nPbH,
                                        int partIdx,
                                        SpatialMergingCandidates* out_cand);
 
-void generate_inter_prediction_samples(class base_context* ctx,
-                                       class de265_image* img,
-                                       class slice_segment_header* shdr,
+void generate_inter_prediction_samples(base_context* ctx,
+                                       struct de265_image* img,
+                                       slice_segment_header* shdr,
                                        int xC,int yC,
                                        int xB,int yB,
                                        int nCS, int nPbW,int nPbH,
@@ -85,10 +88,10 @@ void generate_inter_prediction_samples(class base_context* ctx,
 
 
 
-void decode_prediction_unit(struct thread_context* shdr,
+void decode_prediction_unit(thread_context* shdr,
                             int xC,int yC, int xB,int yB, int nCS, int nPbW,int nPbH, int partIdx);
 
-void inter_prediction(struct decoder_context* ctx,struct slice_segment_header* shdr,
+void inter_prediction(decoder_context* ctx,slice_segment_header* shdr,
                       int xC,int yC, int log2CbSize);
 
 #endif

--- a/libde265/nal.h
+++ b/libde265/nal.h
@@ -31,6 +31,7 @@
 #endif
 
 #include "libde265/bitstream.h"
+#include "libde265/cabac.h"
 
 struct nal_header {
   nal_header() {
@@ -40,7 +41,7 @@ struct nal_header {
   }
 
   void read(bitreader* reader);
-  void write(class CABAC_encoder* writer) const;
+  void write(CABAC_encoder* writer) const;
 
   void set(int unit_type, int layer_id=0, int temporal_id=0) {
     nal_unit_type  =unit_type;

--- a/libde265/pps.cc
+++ b/libde265/pps.cc
@@ -526,7 +526,7 @@ void pic_parameter_set::set_derived_values(const seq_parameter_set* sps)
 }
 
 
-bool pic_parameter_set::write(struct error_queue* errqueue, class CABAC_encoder* out,
+bool pic_parameter_set::write(error_queue* errqueue, CABAC_encoder* out,
                               const seq_parameter_set* sps)
 {
   if (pic_parameter_set_id >= DE265_MAX_PPS_SETS) {

--- a/libde265/pps.h
+++ b/libde265/pps.h
@@ -29,13 +29,15 @@
 #define DE265_MAX_TILE_COLUMNS 10
 #define DE265_MAX_TILE_ROWS    10
 
+class decoder_context;
 
-struct pic_parameter_set {
+class pic_parameter_set {
+public:
   pic_parameter_set();
   ~pic_parameter_set();
 
-  bool read(bitreader*, struct decoder_context*);
-  bool write(struct error_queue*, class CABAC_encoder*,
+  bool read(bitreader*, decoder_context*);
+  bool write(error_queue*, CABAC_encoder*,
              const seq_parameter_set* sps);
 
   bool is_tile_start_CTB(int ctbX,int ctbY) const;

--- a/libde265/sao.cc
+++ b/libde265/sao.cc
@@ -437,7 +437,7 @@ bool add_sao_tasks(image_unit* imgunit, int saoInputProgress)
       task->inputProgress = saoInputProgress;
 
       imgunit->tasks.push_back(task);
-      add_task(&ctx->thread_pool, task);
+      add_task(&ctx->thread_pool_, task);
       n++;
     }
 

--- a/libde265/sei.h
+++ b/libde265/sei.h
@@ -69,15 +69,14 @@ typedef struct {
 } sei_decoded_picture_hash;
 
 
-struct sei_message {
+typedef struct {
   enum sei_payload_type payload_type;
   int payload_size;
 
   union {
     sei_decoded_picture_hash decoded_picture_hash;
   } data;
-};
-
+} sei_message;
 
 class seq_parameter_set;
 
@@ -85,6 +84,6 @@ const char* sei_type_name(enum sei_payload_type type);
 
 de265_error read_sei(bitreader* reader, sei_message*, bool suffix, const seq_parameter_set* sps);
 void dump_sei(const sei_message*, const seq_parameter_set* sps);
-de265_error process_sei(const sei_message*, class de265_image* img);
+de265_error process_sei(const sei_message*, struct de265_image* img);
 
 #endif

--- a/libde265/slice.cc
+++ b/libde265/slice.cc
@@ -707,7 +707,7 @@ de265_error slice_segment_header::read(bitreader* br, decoder_context* ctx,
 }
 
 
-de265_error slice_segment_header::write(struct error_queue* errqueue, class CABAC_encoder* out,
+de265_error slice_segment_header::write(error_queue* errqueue, CABAC_encoder* out,
                                         const seq_parameter_set* sps,
                                         const pic_parameter_set* pps,
                                         uint8_t nal_unit_type)
@@ -4229,7 +4229,7 @@ void initialize_CABAC_at_slice_segment_start(thread_context* tctx)
 
 void thread_task_slice_segment::work()
 {
-  struct thread_task_slice_segment* data = this;
+  thread_task_slice_segment* data = this;
   thread_context* tctx = data->tctx;
   de265_image* img = tctx->img;
 
@@ -4260,7 +4260,7 @@ void thread_task_slice_segment::work()
 
 void thread_task_ctb_row::work()
 {
-  struct thread_task_ctb_row* data = this;
+  thread_task_ctb_row* data = this;
   thread_context* tctx = data->tctx;
   de265_image* img = tctx->img;
 

--- a/libde265/slice.h
+++ b/libde265/slice.h
@@ -35,6 +35,12 @@
 
 #define MAX_NUM_REF_PICS    16
 
+class decoder_context;
+class thread_context;
+class error_queue;
+class seq_parameter_set;
+class pic_parameter_set;
+
 enum SliceType
   {
     SLICE_TYPE_B = 0,
@@ -164,13 +170,14 @@ inline void copy_context_model_table(context_model_table dst, context_model_tabl
 }
 
 
-typedef struct slice_segment_header {
+class slice_segment_header {
+public:
   slice_segment_header() { }
 
-  de265_error read(bitreader* br, struct decoder_context*, bool* continueDecoding);
-  de265_error write(struct error_queue*, class CABAC_encoder*,
-                    const class seq_parameter_set* sps,
-                    const class pic_parameter_set* pps,
+  de265_error read(bitreader* br, decoder_context*, bool* continueDecoding);
+  de265_error write(error_queue*, CABAC_encoder*,
+                    const seq_parameter_set* sps,
+                    const pic_parameter_set* pps,
                     uint8_t nal_unit_type);
 
   void dump_slice_segment_header(const decoder_context*, int fd) const;
@@ -261,7 +268,7 @@ typedef struct slice_segment_header {
   int SliceQPY;
   int initType;
 
-  void compute_derived_values(const class pic_parameter_set* pps);
+  void compute_derived_values(const pic_parameter_set* pps);
 
 
   // --- data for external modules ---
@@ -289,7 +296,7 @@ typedef struct slice_segment_header {
 
   std::vector<int> RemoveReferencesList; // images that can be removed from the DPB before decoding this slice
 
-} slice_segment_header;
+};
 
 
 
@@ -306,7 +313,7 @@ typedef struct {
 
 
 
-de265_error read_slice_segment_data(struct thread_context* tctx);
+de265_error read_slice_segment_data(thread_context* tctx);
 
 bool alloc_and_init_significant_coeff_ctxIdx_lookupTable();
 void free_significant_coeff_ctxIdx_lookupTable();
@@ -316,7 +323,7 @@ class thread_task_ctb_row : public thread_task
 {
 public:
   bool   firstSliceSubstream;
-  struct thread_context* tctx;
+  thread_context* tctx;
 
   virtual void work();
 };
@@ -325,7 +332,7 @@ class thread_task_slice_segment : public thread_task
 {
 public:
   bool   firstSliceSubstream;
-  struct thread_context* tctx;
+  thread_context* tctx;
 
   virtual void work();
 };

--- a/libde265/sps.cc
+++ b/libde265/sps.cc
@@ -85,7 +85,7 @@ void seq_parameter_set::set_defaults(enum PresetSet)
   sps_max_sub_layers = 1;
   sps_temporal_id_nesting_flag = 0;
 
-  profile_tier_level.general.set_defaults(Profile_Main, 6,2); // TODO
+  profile_tier_level_.general.set_defaults(Profile_Main, 6,2); // TODO
 
   seq_parameter_set_id = 0;
   chroma_format_idc = 1;
@@ -190,7 +190,7 @@ de265_error seq_parameter_set::read(error_queue* errqueue, bitreader* br)
 
   sps_temporal_id_nesting_flag = get_bits(br,1);
 
-  profile_tier_level.read(br, sps_max_sub_layers);
+  profile_tier_level_.read(br, sps_max_sub_layers);
 
   READ_VLC(seq_parameter_set_id, uvlc);
 
@@ -507,7 +507,7 @@ void seq_parameter_set::dump(int fd) const
   LOG1("sps_max_sub_layers      : %d\n", sps_max_sub_layers);
   LOG1("sps_temporal_id_nesting_flag : %d\n", sps_temporal_id_nesting_flag);
 
-  profile_tier_level.dump(sps_max_sub_layers, fh);
+  profile_tier_level_.dump(sps_max_sub_layers, fh);
 
   LOG1("seq_parameter_set_id    : %d\n", seq_parameter_set_id);
   LOG2("chroma_format_idc       : %d (%s)\n", chroma_format_idc,
@@ -916,7 +916,7 @@ de265_error seq_parameter_set::write(error_queue* errqueue, CABAC_encoder* out)
 
   out->write_bit(sps_temporal_id_nesting_flag);
 
-  profile_tier_level.write(out, sps_max_sub_layers);
+  profile_tier_level_.write(out, sps_max_sub_layers);
 
   out->write_uvlc(seq_parameter_set_id);
 

--- a/libde265/sps.h
+++ b/libde265/sps.h
@@ -25,8 +25,11 @@
 #include "libde265/bitstream.h"
 #include "libde265/refpic.h"
 #include "libde265/de265.h"
+#include "libde265/cabac.h"
 
 #include <vector>
+
+class error_queue;
 
 // #define MAX_REF_PIC_SETS 64  // maximum according to standard
 #define MAX_NUM_LT_REF_PICS_SPS 32
@@ -55,12 +58,13 @@ enum PresetSet {
   Preset_Default
 };
 
-struct seq_parameter_set {
+class seq_parameter_set {
+public:
   seq_parameter_set();
   ~seq_parameter_set();
 
-  de265_error read(struct error_queue*, bitreader*);
-  de265_error write(struct error_queue*, class CABAC_encoder*);
+  de265_error read(error_queue*, bitreader*);
+  de265_error write(error_queue*, CABAC_encoder*);
 
   void dump(int fd) const;
 
@@ -76,7 +80,7 @@ struct seq_parameter_set {
   char sps_max_sub_layers;            // [1;7]
   char sps_temporal_id_nesting_flag;
 
-  struct profile_tier_level profile_tier_level;
+  profile_tier_level profile_tier_level_;
 
   int seq_parameter_set_id;
   int chroma_format_idc;

--- a/libde265/util.cc
+++ b/libde265/util.cc
@@ -191,14 +191,14 @@ void printBlk(const char* title, const uint8_t* data, int blksize, int stride)
 }
 
 
-static void (*debug_image_output_func)(const class de265_image*, int slot) = NULL;
+static void (*debug_image_output_func)(const struct de265_image*, int slot) = NULL;
 
-void debug_set_image_output(void (*func)(const class de265_image*, int slot))
+void debug_set_image_output(void (*func)(const struct de265_image*, int slot))
 {
   debug_image_output_func = func;
 }
 
-void debug_show_image(const class de265_image* img, int slot)
+void debug_show_image(const struct de265_image* img, int slot)
 {
   if (debug_image_output_func) {
     debug_image_output_func(img,slot);

--- a/libde265/util.h
+++ b/libde265/util.h
@@ -153,7 +153,7 @@ void log2fh(FILE* fh, const char* string, ...);
 void printBlk(const char* title,const int16_t* data, int blksize, int stride);
 void printBlk(const char* title,const uint8_t* data, int blksize, int stride);
 
-void debug_set_image_output(void (*)(const class de265_image*, int slot));
-void debug_show_image(const class de265_image*, int slot);
+void debug_set_image_output(void (*)(const struct de265_image*, int slot));
+void debug_show_image(const struct de265_image*, int slot);
 
 #endif

--- a/libde265/vps.cc
+++ b/libde265/vps.cc
@@ -69,7 +69,7 @@ void video_parameter_set::set_defaults(enum profile_idc profile, int level_major
   vps_max_sub_layers = 1; // temporal sub-layers
   vps_temporal_id_nesting_flag = 1;
 
-  profile_tier_level.general.set_defaults(profile,level_major,level_minor);
+  profile_tier_level_.general.set_defaults(profile,level_major,level_minor);
 
   vps_sub_layer_ordering_info_present_flag = 0;
   layer[0].vps_max_dec_pic_buffering = 1;
@@ -116,7 +116,7 @@ de265_error video_parameter_set::read(error_queue* errqueue, bitreader* reader)
   vps_temporal_id_nesting_flag = get_bits(reader,1);
   skip_bits(reader, 16);
 
-  profile_tier_level.read(reader, vps_max_sub_layers);
+  profile_tier_level_.read(reader, vps_max_sub_layers);
 
   /*
     read_bit_rate_pic_rate_info(reader, &bit_rate_pic_rate_info,
@@ -214,7 +214,7 @@ de265_error video_parameter_set::read(error_queue* errqueue, bitreader* reader)
 }
 
 
-de265_error video_parameter_set::write(struct error_queue* errqueue, struct CABAC_encoder* out) const
+de265_error video_parameter_set::write(error_queue* errqueue, CABAC_encoder* out) const
 {
   if (video_parameter_set_id >= DE265_MAX_VPS_SETS) return DE265_ERROR_CODED_PARAMETER_OUT_OF_RANGE;
   out->write_bits(video_parameter_set_id,4);
@@ -228,7 +228,7 @@ de265_error video_parameter_set::write(struct error_queue* errqueue, struct CABA
   out->write_bit(vps_temporal_id_nesting_flag);
   out->write_bits(0xFFFF, 16);
 
-  profile_tier_level.write(out, vps_max_sub_layers);
+  profile_tier_level_.write(out, vps_max_sub_layers);
 
   /*
   read_bit_rate_pic_rate_info(reader, &bit_rate_pic_rate_info,
@@ -455,7 +455,7 @@ void video_parameter_set::dump(int fd) const
   LOG1("vps_max_sub_layers                    : %d\n", vps_max_sub_layers);
   LOG1("vps_temporal_id_nesting_flag          : %d\n", vps_temporal_id_nesting_flag);
 
-  profile_tier_level.dump(vps_max_sub_layers, fh);
+  profile_tier_level_.dump(vps_max_sub_layers, fh);
   //dump_bit_rate_pic_rate_info(&bit_rate_pic_rate_info, 0, vps_max_sub_layers-1);
 
   LOG1("vps_sub_layer_ordering_info_present_flag : %d\n",

--- a/libde265/vps.h
+++ b/libde265/vps.h
@@ -31,8 +31,11 @@
 
 #include "libde265/bitstream.h"
 #include "libde265/de265.h"
+#include "libde265/cabac.h"
 
 #include <vector>
+
+class error_queue;
 
 #define MAX_TEMPORAL_SUBLAYERS 8
 
@@ -45,10 +48,10 @@ enum profile_idc {
 };
 
 
-struct profile_data {
-
+class profile_data {
+public:
   void read(bitreader* reader);
-  void write(class CABAC_encoder* writer) const;
+  void write(CABAC_encoder* writer) const;
   void dump(bool general, FILE* fh) const;
 
   void set_defaults(enum profile_idc, int level_major, int level_minor);
@@ -80,15 +83,15 @@ class profile_tier_level
 {
 public:
   void read(bitreader* reader, int max_sub_layers);
-  void write(class CABAC_encoder* writer, int max_sub_layers) const;
+  void write(CABAC_encoder* writer, int max_sub_layers) const;
   void dump(int max_sub_layers, FILE* fh) const;
 
-  struct profile_data general;
+  profile_data general;
 
   //bool sub_layer_profile_present[MAX_TEMPORAL_SUBLAYERS];
   //bool sub_layer_level_present[MAX_TEMPORAL_SUBLAYERS];
 
-  struct profile_data sub_layer[MAX_TEMPORAL_SUBLAYERS];
+  profile_data sub_layer[MAX_TEMPORAL_SUBLAYERS];
 };
 
 
@@ -126,8 +129,8 @@ typedef struct {
 class video_parameter_set
 {
 public:
-  de265_error read(struct error_queue* errqueue, bitreader* reader);
-  de265_error write(struct error_queue* errqueue, struct CABAC_encoder* out) const;
+  de265_error read(error_queue* errqueue, bitreader* reader);
+  de265_error write(error_queue* errqueue, CABAC_encoder* out) const;
   void dump(int fd) const;
 
   void set_defaults(enum profile_idc profile, int level_major, int level_minor);
@@ -136,7 +139,7 @@ public:
   int vps_max_layers;            // [1;?]  currently always 1
   int vps_max_sub_layers;        // [1;7]  number of temporal sub-layers
   int vps_temporal_id_nesting_flag; // indicate temporal up-switching always possible
-  struct profile_tier_level profile_tier_level;
+  profile_tier_level profile_tier_level_;
 
   int vps_sub_layer_ordering_info_present_flag;
   layer_data layer[MAX_TEMPORAL_SUBLAYERS];


### PR DESCRIPTION
Mixing `class` and `struct` can cause linking problems with MSVC. See these links for reference:
https://alfps.wordpress.com/2010/06/22/cppx-is-c4099-really-a-sillywarning-disabling-msvc-sillywarnings/#decoration
http://stackoverflow.com/a/468558/608954

This PR changes all internal objects to classes if they have at least one method.
