### PR TITLE
Fix push_end_of_frame function

### DIFF
--- a/libde265/de265.cc
+++ b/libde265/de265.cc
@@ -322,6 +322,7 @@ LIBDE265_API void        de265_push_end_of_frame(de265_decoder_context* de265ctx
   de265_push_end_of_NAL(de265ctx);
 
   decoder_context* ctx = (decoder_context*)de265ctx;
+  ctx->nal_parser.flush_data();
   ctx->nal_parser.mark_end_of_frame();
 }
 

--- a/libde265/decctx.cc
+++ b/libde265/decctx.cc
@@ -1114,7 +1114,7 @@ de265_error decoder_context::decode(int* more)
   // if the stream has ended, and no more NALs are to be decoded, flush all pictures
 
   if (ctx->nal_parser.get_NAL_queue_length() == 0 &&
-      ctx->nal_parser.is_end_of_stream() &&
+      (ctx->nal_parser.is_end_of_stream() || ctx->nal_parser.is_end_of_frame()) &&
       ctx->image_units.empty()) {
 
     // flush all pending pictures into output queue


### PR DESCRIPTION
Fix push_end_of_frame function to force all pending data to be decoded and pushed to picture output queue.