### PR TITLE
Run some libde265 tests on ARM using qemu.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
   - HOST= WINE= DECODESTREAMS=libde265-teststreams-wpp-nolf
   - HOST=i686-w64-mingw32 WINE=wine DECODESTREAMS=
   - HOST=x86_64-w64-mingw32 WINE=wine64 DECODESTREAMS=
+  - HOST=arm-linux-gnueabihf WINE= DECODESTREAMS=
 
 matrix:
   include:
@@ -23,9 +24,10 @@ before_install:
   - sh -c "if [ ! -z '$DECODESTREAMS' ]; then sudo add-apt-repository -y ppa:strukturag/libde265; fi"
   - sudo apt-get update -qq
   - sh -c "if [ -z '$HOST' ]; then sudo apt-get install -qq valgrind libsdl-dev libqt4-dev libswscale-dev; fi"
-  - sh -c "if [ ! -z '$HOST' ]; then sudo apt-get install -qq wine; fi"
+  - sh -c "if [ ! -z '$WINE' ]; then sudo apt-get install -qq wine; fi"
   - sh -c "if [ '$WINE' = 'wine'   ]; then sudo apt-get install -qq gcc-mingw-w64-i686   g++-mingw-w64-i686   binutils-mingw-w64-i686   mingw-w64-dev; fi"
   - sh -c "if [ '$WINE' = 'wine64' ]; then sudo apt-get install -qq gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 binutils-mingw-w64-x86-64 mingw-w64-dev; fi"
+  - sh -c "if ( echo '$HOST' | grep -q '^arm' ); then sudo apt-get install -qq g++-arm-linux-gnueabihf gcc-arm-linux-gnueabihf qemu-user; fi"
   - sh -c "if [ ! -z '$DECODESTREAMS' ]; then sudo apt-get install $DECODESTREAMS; fi"
 
 install:
@@ -43,8 +45,12 @@ script:
   - sh -c "if [ -z "$HOST" ] && [ -z "$DECODESTREAMS" ]; then LD_LIBRARY_PATH=./libde265/.libs/ valgrind --tool=memcheck --quiet --error-exitcode=1 ./dec265/.libs/dec265 -t 4 -q -c -f 100 ./libde265-data/IDR-only/paris-352x288-intra.bin; fi"
   - sh -c "if [ -z "$HOST" ] && [ -z "$DECODESTREAMS" ]; then LD_LIBRARY_PATH=./libde265/.libs/ valgrind --tool=memcheck --quiet --error-exitcode=1 ./dec265/.libs/dec265 -q -c -f 100 ./libde265-data/RandomAccess/paris-ra-wpp.bin; fi"
   - sh -c "if [ -z "$HOST" ] && [ -z "$DECODESTREAMS" ]; then LD_LIBRARY_PATH=./libde265/.libs/ valgrind --tool=memcheck --quiet --error-exitcode=1 ./dec265/.libs/dec265 -t 4 -q -c -f 100 ./libde265-data/RandomAccess/paris-ra-wpp.bin; fi"
-  - sh -c "if [ ! -z "$HOST" ]; then WINEPREFIX=`pwd`/$WINE WINEPATH=/usr/lib/gcc/$HOST/4.6/ $WINE ./dec265/dec265.exe -q -c ./libde265-data/IDR-only/paris-352x288-intra.bin; fi"
-  - sh -c "if [ ! -z "$HOST" ]; then WINEPREFIX=`pwd`/$WINE WINEPATH=/usr/lib/gcc/$HOST/4.6/ $WINE ./dec265/dec265.exe -t 4 -q -c ./libde265-data/IDR-only/paris-352x288-intra.bin; fi"
-  - sh -c "if [ ! -z "$HOST" ]; then WINEPREFIX=`pwd`/$WINE WINEPATH=/usr/lib/gcc/$HOST/4.6/ $WINE ./dec265/dec265.exe -q -c ./libde265-data/RandomAccess/paris-ra-wpp.bin; fi"
-  - sh -c "if [ ! -z "$HOST" ]; then WINEPREFIX=`pwd`/$WINE WINEPATH=/usr/lib/gcc/$HOST/4.6/ $WINE ./dec265/dec265.exe -t 4 -q -c ./libde265-data/RandomAccess/paris-ra-wpp.bin; fi"
+  - sh -c "if [ ! -z "$WINE" ]; then WINEPREFIX=`pwd`/$WINE WINEPATH=/usr/lib/gcc/$HOST/4.6/ $WINE ./dec265/dec265.exe -q -c ./libde265-data/IDR-only/paris-352x288-intra.bin; fi"
+  - sh -c "if [ ! -z "$WINE" ]; then WINEPREFIX=`pwd`/$WINE WINEPATH=/usr/lib/gcc/$HOST/4.6/ $WINE ./dec265/dec265.exe -t 4 -q -c ./libde265-data/IDR-only/paris-352x288-intra.bin; fi"
+  - sh -c "if [ ! -z "$WINE" ]; then WINEPREFIX=`pwd`/$WINE WINEPATH=/usr/lib/gcc/$HOST/4.6/ $WINE ./dec265/dec265.exe -q -c ./libde265-data/RandomAccess/paris-ra-wpp.bin; fi"
+  - sh -c "if [ ! -z "$WINE" ]; then WINEPREFIX=`pwd`/$WINE WINEPATH=/usr/lib/gcc/$HOST/4.6/ $WINE ./dec265/dec265.exe -t 4 -q -c ./libde265-data/RandomAccess/paris-ra-wpp.bin; fi"
+  - sh -c "if ( echo '$HOST' | grep -q '^arm' ); then LD_LIBRARY_PATH=`pwd`/libde265/.libs/ qemu-arm -L /usr/$HOST ./dec265/.libs/dec265 -q -c ./libde265-data/IDR-only/paris-352x288-intra.bin; fi"
+  #- sh -c "if ( echo '$HOST' | grep -q '^arm' ); then LD_LIBRARY_PATH=`pwd`/libde265/.libs/ qemu-arm -L /usr/$HOST ./dec265/.libs/dec265 -t 4 -q -c ./libde265-data/IDR-only/paris-352x288-intra.bin; fi"
+  - sh -c "if ( echo '$HOST' | grep -q '^arm' ); then LD_LIBRARY_PATH=`pwd`/libde265/.libs/ qemu-arm -L /usr/$HOST ./dec265/.libs/dec265 -q -c ./libde265-data/RandomAccess/paris-ra-wpp.bin; fi"
+  #- sh -c "if ( echo '$HOST' | grep -q '^arm' ); then LD_LIBRARY_PATH=`pwd`/libde265/.libs/ qemu-arm -L /usr/$HOST ./dec265/.libs/dec265 -t 4 -q -c ./libde265-data/RandomAccess/paris-ra-wpp.bin; fi"
   - sh -c "if [ ! -z '$DECODESTREAMS' ]; then python scripts/decodestreams.py /var/lib/libde265-teststreams; fi"


### PR DESCRIPTION
Disabled multithreaded decoding for now as they cause qemu-arm to hang after the following assertion
```
qemu-arm: /build/buildd/qemu-linaro-1.0.50-2012.03/user-exec.c:100: handle_cpu_signal: Assertion `({ unsigned long __guest = (unsigned long)(address) - guest_base; (__guest < (1ul << 32)) && (!reserved_va || (__guest < reserved_va)); })' failed.
```