### PR TITLE
Bugfix for decoding of scalable bitstreams (SHVC).

### DIFF
--- a/libde265/decctx.cc
+++ b/libde265/decctx.cc
@@ -1049,6 +1049,13 @@ de265_error decoder_context::decode_NAL(NAL_unit* nal)
   nal_read_header(&reader, &nal_hdr);
   ctx->process_nal_hdr(&nal_hdr);
 
+  if (nal_hdr.nuh_layer_id > 0) {
+    // Discard all NAL units with nuh_layer_id > 0
+    // These will have to be handeled by an SHVC decoder.
+    nal_parser.free_NAL_unit(nal);
+    return DE265_OK;
+  }
+
   loginfo(LogHighlevel,"NAL: 0x%x 0x%x -  unit type:%s temporal id:%d\n",
           nal->data()[0], nal->data()[1],
           get_NAL_name(nal_hdr.nal_unit_type),

--- a/libde265/vps.cc
+++ b/libde265/vps.cc
@@ -34,7 +34,7 @@ de265_error read_vps(decoder_context* ctx, bitreader* reader, video_parameter_se
 
   skip_bits(reader, 2);
   vps->vps_max_layers = vlc = get_bits(reader,6) +1;
-  if (vlc != 1) return DE265_ERROR_CODED_PARAMETER_OUT_OF_RANGE; // TODO: out of specification
+  if (vlc > 63) return DE265_ERROR_CODED_PARAMETER_OUT_OF_RANGE; // vps_max_layers_minus1 (range 0...63)
 
   vps->vps_max_sub_layers = vlc = get_bits(reader,3) +1;
   if (vlc >= MAX_TEMPORAL_SUBLAYERS) return DE265_ERROR_CODED_PARAMETER_OUT_OF_RANGE;


### PR DESCRIPTION
vps_max_layers_minus1 is now allowed. All NAL units with nuh_layer_id > 0 are discarded.