### PR TITLE
Support building encoder on Windows.

### DIFF
--- a/Makefile.vc7
+++ b/Makefile.vc7
@@ -1,3 +1,4 @@
 clean all:
     cd libde265 && $(MAKE) -f Makefile.vc7 $*
     cd dec265 && $(MAKE) -f Makefile.vc7 $*
+    cd enc265 && $(MAKE) -f Makefile.vc7 $*

--- a/build.bat
+++ b/build.bat
@@ -20,6 +20,7 @@ if not exist bin_x86\lib (
     mkdir bin_x86\lib
 )
 copy /y dec265\dec265.exe bin_x86\
+copy /y enc265\enc265.exe bin_x86\
 copy /y libde265\libde265.dll bin_x86\
 copy /y libde265\libde265.lib bin_x86\lib\
 copy /y libde265\libde265.exp bin_x86\lib\
@@ -33,6 +34,7 @@ if not exist bin_x64\lib (
     mkdir bin_x64\lib
 )
 copy /y dec265\dec265.exe bin_x64\
+copy /y enc265\enc265.exe bin_x64\
 copy /y libde265\libde265.dll bin_x64\
 copy /y libde265\libde265.lib bin_x64\lib\
 copy /y libde265\libde265.exp bin_x64\lib\

--- a/enc265/Makefile.vc7
+++ b/enc265/Makefile.vc7
@@ -1,0 +1,33 @@
+#
+# Makefile for Microsoft Visual Studio 2003
+#
+CFLAGS=/I.. /I..\libde265 /I..\extra
+CC=cl /nologo 
+LINK=link /nologo /subsystem:console
+DEFINES=/DWIN32
+
+CFLAGS=$(CFLAGS) /MT /Ob2 /Oi /W4 /EHsc
+CFLAGS=$(CFLAGS) $(DEFINES)
+
+OBJS=\
+	..\extra\getopt_long.obj \
+	..\extra\getopt.obj \
+	enc265.obj
+
+all: enc265.exe
+
+enc265.obj: enc265.cc
+	$(CC) /c $*.cc /Fo$*.obj /TP $(CFLAGS)
+
+.c.obj:
+	$(CC) /c $*.c /Fo$*.obj $(CFLAGS)
+
+.cc.obj:
+	$(CC) /c $*.cc /Fo$*.obj $(CFLAGS)
+
+enc265.exe: $(OBJS) ..\libde265\libde265.lib
+	$(LINK) /out:enc265.exe $** ..\libde265\libde265.lib
+
+clean:
+	del enc265.exe
+	del $(OBJS)

--- a/libde265/Makefile.vc7
+++ b/libde265/Makefile.vc7
@@ -30,22 +30,28 @@ CFLAGS=$(CFLAGS) /wd4800
 CFLAGS=$(CFLAGS) $(DEFINES)
 
 OBJS=\
+	alloc_pool.obj \
 	bitstream.obj \
 	cabac.obj \
+	configparam.obj \
+	contextmodel.obj \
 	de265.obj \
 	deblock.obj \
 	decctx.obj \
 	dpb.obj \
+	en265.obj \
 	fallback-dct.obj \
 	fallback-motion.obj \
 	fallback.obj \
 	image.obj \
+	image-io.obj \
 	intrapred.obj \
 	md5.obj \
 	motion.obj \
 	nal.obj \
 	nal-parser.obj \
 	pps.obj \
+	quality.obj \
 	refpic.obj \
 	sao.obj \
 	scan.obj \
@@ -57,6 +63,24 @@ OBJS=\
 	util.obj \
 	visualize.obj \
 	vps.obj \
+	encoder\analyze.obj \
+	encoder\encode.obj \
+	encoder\encoder-context.obj \
+	encoder\encoder-params.obj \
+	encoder\encpicbuf.obj \
+	encoder\sop.obj \
+	encoder\algo\algo.obj \
+	encoder\algo\cb-interpartmode.obj \
+	encoder\algo\cb-intra-inter.obj \
+	encoder\algo\cb-intrapartmode.obj \
+	encoder\algo\cb-mergeindex.obj \
+	encoder\algo\cb-skip.obj \
+	encoder\algo\cb-split.obj \
+	encoder\algo\coding-options.obj \
+	encoder\algo\ctb-qscale.obj \
+	encoder\algo\pb-mv.obj \
+	encoder\algo\tb-intrapredmode.obj \
+	encoder\algo\tb-split.obj \
 	x86\sse.obj \
 	x86\sse-dct.obj \
 	x86\sse-motion.obj \

--- a/libde265/configparam.h
+++ b/libde265/configparam.h
@@ -94,7 +94,7 @@ class option_base
   bool hasLongOption() const { return true; } //mLongOption!=NULL; }
   std::string getLongOption() const { return mLongOption ? std::string(mLongOption) : get_name(); }
 
-  virtual bool processCmdLineArguments(char** argv, int* argc, int idx) { return false; }
+  virtual LIBDE265_API bool processCmdLineArguments(char** argv, int* argc, int idx) { return false; }
 
 
 
@@ -131,7 +131,7 @@ public:
   virtual std::string get_default_string() const { return default_value ? "true":"false"; }
 
   virtual std::string getTypeDescr() const { return "boolean"; }
-  virtual bool processCmdLineArguments(char** argv, int* argc, int idx) { value=true; return true; }
+  virtual LIBDE265_API bool processCmdLineArguments(char** argv, int* argc, int idx) { value=true; return true; }
 
   bool set(bool v) { value_set=true; value=v; return true; }
 
@@ -161,10 +161,10 @@ public:
   virtual bool has_default() const { return default_set; }
 
   void set_default(std::string v) { default_value=v; default_set=true; }
-  virtual std::string get_default_string() const { return default_value; }
+  virtual LIBDE265_API std::string get_default_string() const { return default_value; }
 
-  virtual std::string getTypeDescr() const { return "(string)"; }
-  virtual bool processCmdLineArguments(char** argv, int* argc, int idx);
+  virtual LIBDE265_API std::string getTypeDescr() const { return "(string)"; }
+  virtual LIBDE265_API bool processCmdLineArguments(char** argv, int* argc, int idx);
 
   bool set(std::string v) { value_set=true; value=v; return true; }
 
@@ -200,10 +200,10 @@ public:
   virtual bool has_default() const { return default_set; }
 
   void set_default(int v) { default_value=v; default_set=true; }
-  virtual std::string get_default_string() const;
+  virtual LIBDE265_API std::string get_default_string() const;
 
-  virtual std::string getTypeDescr() const;
-  virtual bool processCmdLineArguments(char** argv, int* argc, int idx);
+  virtual LIBDE265_API std::string getTypeDescr() const;
+  virtual LIBDE265_API bool processCmdLineArguments(char** argv, int* argc, int idx);
 
   bool set(int v) {
     if (is_valid(v)) { value_set=true; value=v; return true; }
@@ -238,7 +238,7 @@ public:
   virtual std::vector<std::string> get_choice_names() const = 0;
 
   virtual std::string getTypeDescr() const;
-  virtual bool processCmdLineArguments(char** argv, int* argc, int idx);
+  virtual LIBDE265_API bool processCmdLineArguments(char** argv, int* argc, int idx);
 
   const char** get_choices_string_table() const;
 
@@ -361,10 +361,10 @@ class config_parameters
  config_parameters() : param_string_table(NULL) { }
   ~config_parameters() { delete[] param_string_table; }
 
-  void add_option(option_base* o);
+  void LIBDE265_API add_option(option_base* o);
 
-  void print_params() const;
-  bool parse_command_line_params(int* argc, char** argv, int* first_idx=NULL,
+  void LIBDE265_API print_params() const;
+  bool LIBDE265_API parse_command_line_params(int* argc, char** argv, int* first_idx=NULL,
                                  bool ignore_unknown_options=false);
 
 

--- a/libde265/encoder/analyze.h
+++ b/libde265/encoder/analyze.h
@@ -141,6 +141,6 @@ public:
 };
 
 
-void en265_print_logging(const encoder_context* ectx, const char* id, const char* filename);
+LIBDE265_API void en265_print_logging(const encoder_context* ectx, const char* id, const char* filename);
 
 #endif

--- a/libde265/image-io.cc
+++ b/libde265/image-io.cc
@@ -158,7 +158,7 @@ void ImageSink_YUV::send_image(const de265_image* img)
 
 
 
-PacketSink_File::~PacketSink_File()
+LIBDE265_API PacketSink_File::~PacketSink_File()
 {
   if (mFH) {
     fclose(mFH);
@@ -166,7 +166,7 @@ PacketSink_File::~PacketSink_File()
 }
 
 
-void PacketSink_File::set_filename(const char* filename)
+LIBDE265_API void PacketSink_File::set_filename(const char* filename)
 {
   assert(mFH==NULL);
 
@@ -174,7 +174,7 @@ void PacketSink_File::set_filename(const char* filename)
 }
 
 
-void PacketSink_File::send_packet(const uint8_t* data, int n)
+LIBDE265_API void PacketSink_File::send_packet(const uint8_t* data, int n)
 {
   uint8_t startCode[3];
   startCode[0] = 0;

--- a/libde265/image-io.h
+++ b/libde265/image-io.h
@@ -30,17 +30,17 @@
 class ImageSource
 {
  public:
-  ImageSource() { }
-  virtual ~ImageSource() { }
+  LIBDE265_API ImageSource() { }
+  virtual LIBDE265_API ~ImageSource() { }
 
   //enum ImageStatus { Available, Waiting, EndOfVideo };
 
   //virtual ImageStatus  get_status() = 0;
-  virtual de265_image* get_image(bool block=true) = 0;
-  virtual void skip_frames(int n) = 0;
+  virtual LIBDE265_API de265_image* get_image(bool block=true) = 0;
+  virtual LIBDE265_API void skip_frames(int n) = 0;
 
-  virtual int get_width() const = 0;
-  virtual int get_height() const = 0;
+  virtual LIBDE265_API int get_width() const = 0;
+  virtual LIBDE265_API int get_height() const = 0;
 };
 
 
@@ -48,17 +48,17 @@ class ImageSource
 class ImageSource_YUV : public ImageSource
 {
  public:
- ImageSource_YUV() : mFH(NULL) { }
-  virtual ~ImageSource_YUV();
+ LIBDE265_API ImageSource_YUV() : mFH(NULL) { }
+  virtual LIBDE265_API ~ImageSource_YUV();
 
-  bool set_input_file(const char* filename, int w,int h);
+  bool LIBDE265_API set_input_file(const char* filename, int w,int h);
 
   //virtual ImageStatus  get_status();
-  virtual de265_image* get_image(bool block=true);
-  virtual void skip_frames(int n);
+  virtual LIBDE265_API de265_image* get_image(bool block=true);
+  virtual LIBDE265_API void skip_frames(int n);
 
-  virtual int get_width() const { return width; }
-  virtual int get_height() const { return height; }
+  virtual LIBDE265_API int get_width() const { return width; }
+  virtual LIBDE265_API int get_height() const { return height; }
 
  private:
   FILE* mFH;
@@ -75,20 +75,20 @@ class ImageSource_YUV : public ImageSource
 class ImageSink
 {
  public:
-  virtual ~ImageSink() { }
+  virtual LIBDE265_API ~ImageSink() { }
 
-  virtual void send_image(const de265_image* img) = 0;
+  virtual LIBDE265_API void send_image(const de265_image* img) = 0;
 };
 
 class ImageSink_YUV : public ImageSink
 {
  public:
- ImageSink_YUV() : mFH(NULL) { }
-  ~ImageSink_YUV();
+ LIBDE265_API ImageSink_YUV() : mFH(NULL) { }
+  LIBDE265_API ~ImageSink_YUV();
 
-  bool set_filename(const char* filename);
+  bool LIBDE265_API set_filename(const char* filename);
 
-  virtual void send_image(const de265_image* img);
+  virtual LIBDE265_API void send_image(const de265_image* img);
 
  private:
   FILE* mFH;
@@ -99,21 +99,21 @@ class ImageSink_YUV : public ImageSink
 class PacketSink
 {
  public:
-  virtual ~PacketSink() { }
+  virtual LIBDE265_API ~PacketSink() { }
 
-  virtual void send_packet(const uint8_t* data, int n) = 0;
+  virtual LIBDE265_API void send_packet(const uint8_t* data, int n) = 0;
 };
 
 
 class PacketSink_File : public PacketSink
 {
  public:
- PacketSink_File() : mFH(NULL) { }
-  virtual ~PacketSink_File();
+ LIBDE265_API PacketSink_File() : mFH(NULL) { }
+  virtual LIBDE265_API ~PacketSink_File();
 
-  void set_filename(const char* filename);
+  LIBDE265_API void set_filename(const char* filename);
 
-  virtual void send_packet(const uint8_t* data, int n);
+  virtual LIBDE265_API void send_packet(const uint8_t* data, int n);
 
  private:
   FILE* mFH;


### PR DESCRIPTION
This PR exports the API as used by `enc265` and adds building of the encoder code to the `Makefile.vc7` based build system.