### PR TITLE
Support compilation on GCC < 4.6 (i.e. NaCl).

### DIFF
--- a/libde265/configparam.h
+++ b/libde265/configparam.h
@@ -272,13 +272,19 @@ template <class T> class choice_option : public choice_option_base
   }
 
   void set_default(T val) {
-    for (auto c : choices)
+#ifdef FOR_LOOP_AUTO_SUPPORT
+    FOR_LOOP(auto, c, choices) {
+#else
+    for (typename std::vector< std::pair<std::string,T> >::const_iterator it=choices.begin(); it!=choices.end(); ++it) {
+      const std::pair<std::string,T> & c = *it;
+#endif
       if (c.second == val) {
         defaultID = val;
         defaultValue = c.first;
         default_set = true;
         return;
       }
+    }
 
     assert(false); // value does not exist
   }

--- a/libde265/util.h
+++ b/libde265/util.h
@@ -29,6 +29,9 @@
 
 #include "libde265/de265.h"
 
+#ifdef __GNUC__
+#define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+#endif
 
 #ifdef _MSC_VER
 #define LIBDE265_DECLARE_ALIGNED( var, n ) __declspec(align(n)) var
@@ -46,16 +49,22 @@
 #define ALIGNED_4( var )  LIBDE265_DECLARE_ALIGNED( var, 4 )
 
 // C++11 specific features
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || (__GNUC__ && GCC_VERSION < 40600)
 #define FOR_LOOP(type, var, list)   for each (type var in list)
 #undef FOR_LOOP_AUTO_SUPPORT
 #else
 #define FOR_LOOP(type, var, list)   for (type var : list)
 #define FOR_LOOP_AUTO_SUPPORT 1
 #endif
+
 #ifdef USE_STD_TR1_NAMESPACE
 #include <tr1/memory>
 namespace std { using namespace std::tr1; }
+#endif
+
+#if __GNUC__ && GCC_VERSION < 40600
+// nullptr was introduced in gcc 4.6, a simple alias should be fine for our use case
+#define nullptr NULL
 #endif
 
 #ifdef _MSC_VER

--- a/libde265/util.h
+++ b/libde265/util.h
@@ -49,7 +49,7 @@
 #define ALIGNED_4( var )  LIBDE265_DECLARE_ALIGNED( var, 4 )
 
 // C++11 specific features
-#if defined(_MSC_VER) || (__GNUC__ && GCC_VERSION < 40600)
+#if defined(_MSC_VER) || (!__clang__ && __GNUC__ && GCC_VERSION < 40600)
 #define FOR_LOOP(type, var, list)   for each (type var in list)
 #undef FOR_LOOP_AUTO_SUPPORT
 #else


### PR DESCRIPTION
This fixes compiler errors with the Pepper SDK (Native Client).