### PR TITLE
Return correct stride for planes with more than 8 bits per pixel.

### DIFF
--- a/libde265/de265.cc
+++ b/libde265/de265.cc
@@ -624,7 +624,7 @@ LIBDE265_API const uint8_t* de265_get_image_plane(const de265_image* img, int ch
 
   uint8_t* data = img->pixels_confwin[channel];
 
-  if (stride) *stride = img->get_image_stride(channel);
+  if (stride) *stride = img->get_image_stride(channel) * ((de265_get_bits_per_pixel(img, channel)+7) / 8);
 
   return data;
 }

--- a/libde265/de265.cc
+++ b/libde265/de265.cc
@@ -638,6 +638,8 @@ LIBDE265_API void *de265_get_image_plane_user_data(const struct de265_image* img
 
 LIBDE265_API void de265_set_image_plane(de265_image* img, int cIdx, void* mem, int stride, void *userdata)
 {
+  // The internal "stride" is the number of pixels per line.
+  stride = stride / ((de265_get_bits_per_pixel(img, cIdx)+7) / 8);
   img->set_image_plane(cIdx, (uint8_t*)mem, stride, userdata);
 }
 

--- a/libde265/de265.h
+++ b/libde265/de265.h
@@ -166,6 +166,7 @@ LIBDE265_API int de265_get_image_width(const struct de265_image*,int channel);
 LIBDE265_API int de265_get_image_height(const struct de265_image*,int channel);
 LIBDE265_API enum de265_chroma de265_get_chroma_format(const struct de265_image*);
 LIBDE265_API int de265_get_bits_per_pixel(const struct de265_image*,int channel);
+/* The |out_stride| is returned as "bytes per line" if a non-NULL parameter is given. */
 LIBDE265_API const uint8_t* de265_get_image_plane(const struct de265_image*, int channel, int* out_stride);
 LIBDE265_API void* de265_get_image_plane_user_data(const struct de265_image*, int channel);
 LIBDE265_API de265_PTS de265_get_image_PTS(const struct de265_image*);


### PR DESCRIPTION
Currently the returned stride always assumes 8 bits per pixel.