### PR TITLE
Fixed bytes-per-line calculation for bit depths > 8.

### DIFF
--- a/libde265/image.cc
+++ b/libde265/image.cc
@@ -115,8 +115,8 @@ static int  de265_image_get_buffer(de265_decoder_context* ctx,
   assert(img->sps.BitDepth_Y >= 8 && img->sps.BitDepth_Y <= 16);
   assert(img->sps.BitDepth_C >= 8 && img->sps.BitDepth_C <= 16);
 
-  int luma_bpl   = luma_stride   * (img->sps.BitDepth_Y+7)/8;
-  int chroma_bpl = chroma_stride * (img->sps.BitDepth_C+7)/8;
+  int luma_bpl   = luma_stride   * ((img->sps.BitDepth_Y+7)/8);
+  int chroma_bpl = chroma_stride * ((img->sps.BitDepth_C+7)/8);
 
   int luma_height   = spec->height;
   int chroma_height = rawChromaHeight;


### PR DESCRIPTION
Before:
1920 pixels, 10bpp -> 1920*(10+7)/8 = 4080 (i.e. 2.125 bytes per pixel)

After:
1920 pixels, 10bpp -> 1920*((10+7)/8) = 3840 (i.e. 2 bytes per pixel)
