### PR TITLE
Add missing license headers and check headers in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ before_install:
   - sh -c "if [ ! -z '$DECODESTREAMS' ]; then sudo add-apt-repository -y ppa:strukturag/libde265; fi"
   - sudo apt-get update -qq
   - sh -c "if [ -z '$HOST' ]; then sudo apt-get install -qq valgrind libsdl-dev libqt4-dev libswscale-dev; fi"
+  - sh -c "if [ -z '$HOST' ] && [ -z '$DECODESTREAMS' ]; then sudo apt-get install -qq devscripts; fi"
   - sh -c "if [ ! -z '$WINE' ]; then sudo apt-get install -qq wine; fi"
   - sh -c "if [ '$WINE' = 'wine'   ]; then sudo apt-get install -qq gcc-mingw-w64-i686   g++-mingw-w64-i686   binutils-mingw-w64-i686   mingw-w64-dev; fi"
   - sh -c "if [ '$WINE' = 'wine64' ]; then sudo apt-get install -qq gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 binutils-mingw-w64-x86-64 mingw-w64-dev; fi"
@@ -48,6 +49,7 @@ before_script:
   - ./configure --host=$HOST
 
 script:
+  - sh -c "if [ -z "$HOST" ] && [ -z "$DECODESTREAMS" ]; then ./scripts/check_licenses.sh; fi"
   - make
   - sh -c "if [ -z "$HOST" ] && [ -z "$DECODESTREAMS" ]; then LD_LIBRARY_PATH=./libde265/.libs/ valgrind --tool=memcheck --quiet --error-exitcode=1 ./dec265/.libs/dec265 -q -c -f 100 ./libde265-data/IDR-only/paris-352x288-intra.bin; fi"
   - sh -c "if [ -z "$HOST" ] && [ -z "$DECODESTREAMS" ]; then LD_LIBRARY_PATH=./libde265/.libs/ valgrind --tool=memcheck --quiet --error-exitcode=1 ./dec265/.libs/dec265 -t 4 -q -c -f 100 ./libde265-data/IDR-only/paris-352x288-intra.bin; fi"

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,24 @@
 #!/bin/sh
+set -eu
+#
+# H.265 video codec.
+# Copyright (c) 2013 struktur AG, Joachim Bauch <bauch@struktur.de>
+#
+# This file is part of libde265.
+#
+# libde265 is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# libde265 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with libde265.  If not, see <http://www.gnu.org/licenses/>.
+#
 if [ -x "`which autoreconf 2>/dev/null`" ] ; then
    exec autoreconf -ivf
 fi

--- a/scripts/check_licenses.sh
+++ b/scripts/check_licenses.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -eu
+#
+# H.265 video codec.
+# Copyright (c) 2015 struktur AG, Joachim Bauch <bauch@struktur.de>
+#
+# This file is part of libde265.
+#
+# libde265 is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# libde265 is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with libde265.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+echo "Checking licenses..."
+CHECK_RESULT=`/usr/bin/licensecheck --recursive --ignore 'nacl_sdk' .`
+
+# Files that are public domain or have other known-good license headers which licensecheck doesn't detect.
+KNOWN_GOOD_FILES=(
+    './extra/stdint.h',
+    './extra/win32cond.c',
+    './extra/win32cond.h',
+    './libde265/md5.cc',
+    './libde265/md5.h',
+)
+
+FOUND=
+while read -r line; do
+    if ( echo $line | grep -q "GENERATED FILE" ); then
+        # We don't care about generated files
+        echo "OK: $line"
+        continue
+    fi
+
+    if ( echo "$line" | grep -q "No copyright" ) || ( echo "$line" | grep -q "UNKNOWN" ); then
+        FILENAME=`echo "$line" | awk '{split($0,a,":");print a[1]}'`
+        if echo "${KNOWN_GOOD_FILES[@]}" | fgrep -q --word-regexp "${FILENAME}"; then
+            echo "OK: $line (known-good)"
+        else
+            echo "ERROR: $line" >& 2
+            FOUND=1
+        fi
+        continue
+    fi
+
+    echo "OK: $line"
+done <<< "${CHECK_RESULT}"
+
+if [ ! -z ${FOUND} ]; then
+    echo "ERROR: Found files without licenses" >& 2
+    exit 1
+fi

--- a/tools/yuv-distortion.cc
+++ b/tools/yuv-distortion.cc
@@ -1,3 +1,22 @@
+/*
+ * H.265 video codec.
+ * Copyright (c) 2013-2014 struktur AG, Dirk Farin <farin@struktur.de>
+ *
+ * This file is part of libde265.
+ *
+ * libde265 is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * libde265 is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with libde265.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"


### PR DESCRIPTION
This will prevent us from adding files without license headers in the future.