### PR TITLE
Fix order of initializations in constructors.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,7 @@ AC_PROG_GREP
 AM_INIT_AUTOMAKE
 
 CFLAGS+=" -std=c99"
-CXXFLAGS+=" -Werror=return-type -Werror=unused-result"
+CXXFLAGS+=" -Werror=return-type -Werror=unused-result -Werror=reorder"
 AX_CXX_COMPILE_STDCXX_11()
 
 dnl Use -Wall if we have gcc.

--- a/libde265/alloc_pool.cc
+++ b/libde265/alloc_pool.cc
@@ -29,8 +29,8 @@
 
 
 alloc_pool::alloc_pool(size_t objSize, int poolSize, bool grow)
-  : mPoolSize(poolSize),
-    mObjSize(objSize),
+  : mObjSize(objSize),
+    mPoolSize(poolSize),
     mGrow(grow)
 {
   m_freeList.reserve(poolSize);

--- a/libde265/configparam.h
+++ b/libde265/configparam.h
@@ -47,7 +47,7 @@ class option_base
 {
  public:
  option_base() : mShortOption(0), mLongOption(NULL) { }
- option_base(const char* name) : mShortOption(0), mLongOption(NULL), mIDName(name) { }
+ option_base(const char* name) : mIDName(name), mShortOption(0), mLongOption(NULL) { }
   virtual ~option_base() { }
 
 

--- a/libde265/decctx.cc
+++ b/libde265/decctx.cc
@@ -140,15 +140,15 @@ thread_context::thread_context()
 
 
 slice_unit::slice_unit(decoder_context* decctx)
-  : ctx(decctx),
-    nal(NULL),
+  : nal(NULL),
     shdr(NULL),
-    flush_reorder_buffer(false),
-    thread_contexts(NULL),
     imgunit(NULL),
+    flush_reorder_buffer(false),
     nThreads(0),
     first_decoded_CTB_RS(-1),
-    last_decoded_CTB_RS(-1)
+    last_decoded_CTB_RS(-1),
+    thread_contexts(NULL),
+    ctx(decctx)
 {
   state = Unprocessed;
   nThreadContexts = 0;

--- a/libde265/encoder/encode.cc
+++ b/libde265/encoder/encode.cc
@@ -279,11 +279,11 @@ alloc_pool enc_cb::mMemPool(sizeof(enc_cb), 200);
 
 enc_cb::enc_cb()
   : split_cu_flag(false),
+    cu_transquant_bypass_flag(false),
+    pcm_flag(false),
     transform_tree(NULL),
     distortion(0),
-    rate(0),
-    cu_transquant_bypass_flag(false),
-    pcm_flag(false)
+    rate(0)
 {
   if (DEBUG_ALLOCS) { allocCB++; printf("CB  : %d\n",allocCB); }
 }

--- a/sherlock265/VideoDecoder.cc
+++ b/sherlock265/VideoDecoder.cc
@@ -33,7 +33,8 @@ using namespace videogfx;
 
 
 VideoDecoder::VideoDecoder()
-  : ctx(NULL),
+  : mFH(NULL),
+    ctx(NULL),
     img(NULL),
     mNextBuffer(0),
     mFrameCount(0),
@@ -41,16 +42,15 @@ VideoDecoder::VideoDecoder()
     mVideoEnded(false),
     mSingleStep(false),
     mShowDecodedImage(true),
+    mShowQuantPY(false),
     mCBShowPartitioning(false),
     mTBShowPartitioning(false),
     mPBShowPartitioning(false),
-    mShowPBPredMode(false),
     mShowIntraPredMode(false),
-    mShowQuantPY(false),
+    mShowPBPredMode(false),
     mShowMotionVec(false),
-    mShowSlices(false),
     mShowTiles(false),
-    mFH(NULL)
+    mShowSlices(false)
 #ifdef HAVE_SWSCALE
     , sws(NULL)
     , width(0)


### PR DESCRIPTION
Also change compiler flags to error out if order doesn't match declaration.

See http://stackoverflow.com/a/1828048/608954 for a description why this is a good idea.