### PR TITLE
Fixed compilation on systems with older versions of libc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -113,6 +113,31 @@ if eval "test x$need_strict_ansi = xyes"; then
 fi
 AC_MSG_RESULT([$need_strict_ansi])
 
+# Check if "std::shared_ptr" is "std::tr1::shared_ptr"
+AC_MSG_CHECKING([for std::shared_ptr])
+AC_LANG_PUSH(C++)
+AC_TRY_COMPILE([
+#include <memory>
+],[
+class A {};
+std::shared_ptr<A> a;
+],[has_std_shared_ptr=yes],[has_std_shared_ptr=no]);
+AC_MSG_RESULT([$has_std_shared_ptr])
+if eval "test x$has_std_shared_ptr = xno"; then
+  AC_MSG_CHECKING([for std::tr1::shared_ptr])
+  AC_TRY_COMPILE([
+  #include <tr1/memory>
+  ],[
+  class A {};
+  std::tr1::shared_ptr<A> a;
+  ],[has_std_tr1_shared_ptr=yes],[has_std_tr1_shared_ptr=no]);
+  AC_MSG_RESULT([$has_std_tr1_shared_ptr])
+  if eval "test x$has_std_tr1_shared_ptr = xyes"; then
+    AC_DEFINE(USE_STD_TR1_NAMESPACE,1,[Define to 1 if the std::tr1 namespace should be included in the std namespace.])
+  fi
+fi
+AC_LANG_POP(C++)
+
 # Check if "std::move" is available
 AC_MSG_CHECKING([for std::move])
 AC_LANG_PUSH(C++)

--- a/configure.ac
+++ b/configure.ac
@@ -113,6 +113,22 @@ if eval "test x$need_strict_ansi = xyes"; then
 fi
 AC_MSG_RESULT([$need_strict_ansi])
 
+# Check if "std::move" is available
+AC_MSG_CHECKING([for std::move])
+AC_LANG_PUSH(C++)
+AC_TRY_COMPILE([
+#include <utility>
+],[
+class A {};
+A* a = new A();
+A* b = std::move(a);
+],[has_std_move=yes],[has_std_move=no]);
+AC_LANG_POP(C++)
+if eval "test x$has_std_move = xno"; then
+  AC_DEFINE(NEED_STD_MOVE_FALLBACK,1,[Define to 1 if a fallback for "std::move" is required.])
+fi
+AC_MSG_RESULT([$has_std_move])
+
 # --- machine dependent optimizations ---
 
 #AX_EXT

--- a/configure.ac
+++ b/configure.ac
@@ -58,6 +58,13 @@ AM_CONDITIONAL([HAVE_VISIBILITY], [test "x$HAVE_VISIBILITY" != "x0"])
 # Checks for header files.
 AC_CHECK_HEADERS([stdint.h stdlib.h string.h malloc.h signal.h setjmp.h stddef.h sys/time.h])
 
+AC_LANG_PUSH(C++)
+OLD_CPPFLAGS="$CPPFLAGS"
+CPPFLAGS="$CXXFLAGS"
+AC_CHECK_HEADERS([cstdint])
+CPPFLAGS="$OLD_CPPFLAGS"
+AC_LANG_POP(C++)
+
 # Checks for typedefs, structures, and compiler characteristics.
 AC_HEADER_STDBOOL
 AC_TYPE_SIZE_T

--- a/libde265/alloc_pool.h
+++ b/libde265/alloc_pool.h
@@ -23,11 +23,16 @@
 #ifndef ALLOC_POOL_H
 #define ALLOC_POOL_H
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <vector>
 #include <cstddef>
 #ifdef HAVE_STDINT_H
 #include <stdint.h>
-#else
+#endif
+#ifdef HAVE_CSTDINT
 #include <cstdint>
 #endif
 

--- a/libde265/util.h
+++ b/libde265/util.h
@@ -21,6 +21,10 @@
 #ifndef DE265_UTIL_H
 #define DE265_UTIL_H
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #ifndef _MSC_VER
 #include <inttypes.h>
 #endif
@@ -68,6 +72,19 @@
 #ifdef USE_STD_TR1_NAMESPACE
 #include <tr1/memory>
 namespace std { using namespace std::tr1; }
+#endif
+
+#ifdef NEED_STD_MOVE_FALLBACK
+// Provide fallback variant of "std::move" for older compilers with
+// incomplete/broken C++11 support.
+namespace std {
+
+template<typename _Tp>
+inline typename std::remove_reference<_Tp>::type&& move(_Tp&& __t) {
+  return static_cast<typename std::remove_reference<_Tp>::type&&>(__t);
+}
+
+}  // namespace std
 #endif
 
 #if __GNUC__ && GCC_VERSION < 40600

--- a/libde265/x86/sse-motion.cc
+++ b/libde265/x86/sse-motion.cc
@@ -19,6 +19,10 @@
  * along with libde265.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <stdio.h>
 #include <emmintrin.h>
 #include <tmmintrin.h> // SSSE3


### PR DESCRIPTION
Happens for example on OSX when compiling with the 10.10 SDK for a deployment target of 10.6.