### PR TITLE
Fix linking errors on AppVeyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ matrix:
 
 before_install:
   - sh -c "if [ ! -z '$DECODESTREAMS' ]; then sudo add-apt-repository -y ppa:strukturag/libde265; fi"
+  - sh -c "if [ '$HOST' = 'cmake' ]; then sudo add-apt-repository -y ppa:kalakris/cmake; fi"
   - sudo apt-get update -qq
   - sh -c "if [ -z '$HOST' ]; then sudo apt-get install -qq valgrind libsdl-dev libqt4-dev libswscale-dev; fi"
   - sh -c "if [ -z '$HOST' ] && [ -z '$DECODESTREAMS' ]; then sudo apt-get install -qq devscripts; fi"
@@ -39,6 +40,7 @@ before_install:
   - sh -c "if [ '$WINE' = 'wine64' ]; then sudo apt-get install -qq gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 binutils-mingw-w64-x86-64 mingw-w64-dev; fi"
   - sh -c "if ( echo '$HOST' | grep -q '^arm' ); then sudo apt-get install -qq g++-arm-linux-gnueabihf gcc-arm-linux-gnueabihf qemu-user; fi"
   - sh -c "if [ ! -z '$DECODESTREAMS' ]; then sudo apt-get install $DECODESTREAMS; fi"
+  - sh -c "if [ '$HOST' = 'cmake' ]; then sudo apt-get install cmake; fi"
 
 install:
   - git clone https://github.com/strukturag/libde265-data.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project (libde265)
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 2.8.8)
 
 # The version number.
 set (NUMERIC_VERSION 0x01000000)

--- a/enc265/enc265.cc
+++ b/enc265/enc265.cc
@@ -175,7 +175,7 @@ void test_parameters_API(en265_encoder_context* ectx)
 extern int skipTBSplit, noskipTBSplit;
 extern int zeroBlockCorrelation[6][2][5];
 
-extern ImageSink_YUV reconstruction_sink;
+LIBDE265_API ImageSink_YUV reconstruction_sink;
 
 int main(int argc, char** argv)
 {

--- a/libde265/CMakeLists.txt
+++ b/libde265/CMakeLists.txt
@@ -65,20 +65,16 @@ endif()
 
 add_definitions(-DLIBDE265_EXPORTS)
 
-add_library(${LIBDE265_LIBRARY_NAME} SHARED ${libde265_sources})
+add_subdirectory (encoder)
 
+if(SUPPORTS_SSE4_1)
+  add_definitions(-DHAVE_SSE4_1)
+  add_subdirectory (x86)
+endif()
+
+add_library(${LIBDE265_LIBRARY_NAME} SHARED ${libde265_sources} ${ENCODER_OBJECTS} ${X86_OBJECTS})
 target_link_libraries(${LIBDE265_LIBRARY_NAME} ${CMAKE_THREAD_LIBS_INIT})
 
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
   SET_TARGET_PROPERTIES(${LIBDE265_LIBRARY_NAME} PROPERTIES COMPILE_FLAGS "-fPIC")
 endif(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-
-add_subdirectory (encoder)
-
-target_link_libraries(${LIBDE265_LIBRARY_NAME} encoder)
-
-if(SUPPORTS_SSE4_1)
-  add_definitions(-DHAVE_SSE4_1)
-  add_subdirectory (x86)
-  target_link_libraries(${LIBDE265_LIBRARY_NAME} x86)
-endif()

--- a/libde265/Makefile.vc7
+++ b/libde265/Makefile.vc7
@@ -4,7 +4,7 @@
 CFLAGS=/I..\extra /I.. /I.
 CC=cl /nologo
 LINK=link /nologo /subsystem:console
-DEFINES=/DWIN32 /D_WIN32_WINNT=0x0400 /DNDEBUG /DLIBDE265_EXPORTS /D_CRT_SECURE_NO_WARNINGS /DHAVE_SSE4_1 /DNOMINMAX
+DEFINES=/DWIN32 /D_WIN32_WINNT=0x0400 /DNDEBUG /DLIBDE265_EXPORTS /D_CRT_SECURE_NO_WARNINGS /DHAVE_SSE4_1 /DNOMINMAX /DHAVE_STDINT_H
 
 CFLAGS=$(CFLAGS) /MT /Ox /Ob2 /Oi /TP /W4 /GL /EHsc
 
@@ -84,6 +84,7 @@ OBJS=\
 	encoder\algo\tb-intrapredmode.obj \
 	encoder\algo\tb-rateestim.obj \
 	encoder\algo\tb-split.obj \
+	encoder\algo\tb-transform.obj \
 	x86\sse.obj \
 	x86\sse-dct.obj \
 	x86\sse-motion.obj \

--- a/libde265/encoder/CMakeLists.txt
+++ b/libde265/encoder/CMakeLists.txt
@@ -8,12 +8,10 @@ set (encoder_sources
   sop.h sop.cc
 )
 
-add_library(encoder STATIC ${encoder_sources})
+add_subdirectory (algo)
+add_library(encoder OBJECT ${encoder_sources})
+set(ENCODER_OBJECTS $<TARGET_OBJECTS:encoder> ${ALGO_OBJECTS} PARENT_SCOPE)
 
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
   SET_TARGET_PROPERTIES(encoder PROPERTIES COMPILE_FLAGS "-fPIC")
 endif(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-
-add_subdirectory (algo)
-
-target_link_libraries(encoder algo)

--- a/libde265/encoder/algo/CMakeLists.txt
+++ b/libde265/encoder/algo/CMakeLists.txt
@@ -15,7 +15,8 @@ set (algo_sources
   pb-mv.h pb-mv.cc
 )
 
-add_library(algo STATIC ${algo_sources})
+add_library(algo OBJECT ${algo_sources})
+set(ALGO_OBJECTS $<TARGET_OBJECTS:algo> PARENT_SCOPE)
 
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
   SET_TARGET_PROPERTIES(algo PROPERTIES COMPILE_FLAGS "-fPIC")

--- a/libde265/encoder/encoder-core.cc
+++ b/libde265/encoder/encoder-core.cc
@@ -121,7 +121,7 @@ void print_cb_tree_rates(const enc_cb* cb, int level)
 }
 
 
-ImageSink_YUV reconstruction_sink;
+LIBDE265_API ImageSink_YUV reconstruction_sink;
 
 double encode_image(encoder_context* ectx,
                     const de265_image* input,

--- a/libde265/x86/CMakeLists.txt
+++ b/libde265/x86/CMakeLists.txt
@@ -6,9 +6,9 @@ set (x86_sse_sources
   sse-motion.cc sse-motion.h sse-dct.h sse-dct.cc
 )
 
-add_library(x86 STATIC ${x86_sources})
+add_library(x86 OBJECT ${x86_sources})
 
-add_library(x86_sse STATIC ${x86_sse_sources})
+add_library(x86_sse OBJECT ${x86_sse_sources})
 
 set(sse_flags "")
 
@@ -16,7 +16,7 @@ if(NOT MSVC)
   set(sse_flags "${sse_flags} -msse4.1")
 endif()
 
-target_link_libraries(x86 x86_sse)
+set(X86_OBJECTS $<TARGET_OBJECTS:x86> $<TARGET_OBJECTS:x86_sse> PARENT_SCOPE)
 
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
   SET_TARGET_PROPERTIES(x86 PROPERTIES COMPILE_FLAGS "-fPIC")


### PR DESCRIPTION
This PR fixes the linking errors when compiling with cmake as seen on AppVeyor.