### PR TITLE
Crash when the bitstream contains a CRA and following RASL pictures

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,4 +40,12 @@ test_script:
   - build\dec265.exe -t 4 -q -c -f 100 libde265-data\RandomAccess\paris-ra-wpp.bin
 
 artifacts:
-  - path: build
+  - path: libde265/Release/libde265.dll
+
+deploy:
+  provider: GitHub
+  auth_token:
+    secure: boWJ9aVfVBpOkBGzWF5yS5/Os3eDUjFfziOY04+LNA+7v+PnMFBtHeMJe2PjK4gm
+  artifact: libde265/Release/libde265.dll
+  on:
+    appveyor_repo_tag: true        # deploy on tag push only

--- a/libde265/decctx.cc
+++ b/libde265/decctx.cc
@@ -2039,6 +2039,8 @@ bool decoder_context::process_slice_segment_header(slice_segment_header* hdr,
         NoRaslOutputFlag)
       {
         img->PicOutputFlag = false;
+        // This is a RASL but we are not going to output (decode) RASLs.
+        return false;
       }
     else
       {
@@ -2064,6 +2066,11 @@ bool decoder_context::process_slice_segment_header(slice_segment_header* hdr,
     first_decoded_picture = false;
   }
   else {
+    if (isRASL(nal_unit_type) && NoRaslOutputFlag) {
+      // Not the first slice, a RASL, and we are not outputting (decoding) RASLS.
+      return false;
+    }
+
     // claims to be not the first slice, but there is no active image available
 
     if (img == NULL) {

--- a/libde265/decctx.cc
+++ b/libde265/decctx.cc
@@ -798,8 +798,7 @@ de265_error decoder_context::decode_slice_unit_sequential(image_unit* imgunit,
                      sliceunit->reader.bytes_remaining);
 
   // alloc CABAC-model array if entropy_coding_sync is enabled
-
-  if (pps->entropy_coding_sync_enabled_flag &&
+  if (current_pps->entropy_coding_sync_enabled_flag &&
       sliceunit->shdr->first_slice_segment_in_pic_flag) {
     imgunit->ctx_models.resize( (img->sps.PicHeightInCtbsY-1) * CONTEXT_MODEL_TABLE_LENGTH );
   }


### PR DESCRIPTION
When RASL pictures are encountered after a random access picture and this random access picture is the first one to be decoded, the decoder crashes. In this case the decoder should ignore the following RASL pictures.
The bugfix fixes this issue but I am not 100% shure if there isn't a better way of doing this.
I have a sample bitstream for this, unfortunately I cannot attach it here.
