### PR TITLE
SSE dectetion made wrong assumptions on SSSE3-less processor

### DIFF
--- a/libde265/CMakeLists.txt
+++ b/libde265/CMakeLists.txt
@@ -54,6 +54,7 @@ set (libde265_sources
   acceleration.h
   fallback.cc fallback.h fallback-motion.cc fallback-motion.h
   fallback-dct.h fallback-dct.cc fallback-sao.h fallback-sao.cc
+  fallback-intra-dc.cc
   quality.cc quality.h
   configparam.cc configparam.h
   image-io.h image-io.cc

--- a/libde265/x86/sse.cc
+++ b/libde265/x86/sse.cc
@@ -76,7 +76,7 @@ void init_acceleration_functions_sse(struct acceleration_functions* accel,
   int have_SSE    = !!(edx & (1<<25));
   int have_SSE2   = !!(edx & (1<<26));
   int have_SSE3   = !!(ecx & (1<< 0));
-  int have_SSSE3  = !!(edx & (1<< 9));
+  int have_SSSE3  = !!(ecx & (1<< 9));
   int have_SSE4_1 = !!(ecx & (1<<19));
   int have_SSE4_2 = !!(ecx & (1<<20));
   int have_AVX    = !!(ecx & (1<<28));
@@ -94,22 +94,25 @@ void init_acceleration_functions_sse(struct acceleration_functions* accel,
   }
 
 #if HAVE_SSE4_1
-  if (have_SSE2) {
+  if (have_SSE4_1) {
     accel->put_unweighted_pred_8   = put_pred_8_sse2;
     accel->put_weighted_pred_avg_8 = put_bipred_8_sse2;
   }
 
   if (have_SSSE3) { accel->put_weighted_pred_8 = put_weighted_pred_8_ssse3; }
+
   if (have_SSE2)  { accel->put_weighted_bipred_8 = put_weighted_bipred_8_sse2; }
 
-  if (have_SSE2) { accel->put_hevc_epel_8    = put_hevc_chroma_direct_8_sse2; }
+  if (have_SSE4_1) { accel->put_hevc_epel_8    = put_hevc_chroma_direct_8_sse2; }
+
   if (have_SSE4_1) { // TODO: check requirements
     accel->put_hevc_epel_h_8  = ff_hevc_put_hevc_epel_h_8_sse;
     accel->put_hevc_epel_v_8  = ff_hevc_put_hevc_epel_v_8_sse;
     accel->put_hevc_epel_hv_8 = ff_hevc_put_hevc_epel_hv_8_sse;
   }
 
-  if (have_SSE2) { accel->put_hevc_qpel_8[0][0] = put_hevc_luma_direct_8_sse2; }
+  if (have_SSE4_1) { accel->put_hevc_qpel_8[0][0] = put_hevc_luma_direct_8_sse2; }
+
   if (have_SSE4_1) { // TODO: check requirements
     accel->put_hevc_qpel_8[0][1] = ff_hevc_put_hevc_qpel_v_1_8_sse;
     accel->put_hevc_qpel_8[0][2] = ff_hevc_put_hevc_qpel_v_2_8_sse;
@@ -152,6 +155,6 @@ void init_acceleration_functions_sse(struct acceleration_functions* accel,
   if (have_SSSE3) { accel->intra_dc_noavg_8[3] = intra_dc_noavg_8_32x32_ssse3; }
   accel->intra_dc_avg_8[3]   = nullptr;
 
-  if (have_SSE2) { accel->sao_band_8 = sao_band_8bit_sse2; }
+  if (have_SSSE3) { accel->sao_band_8 = sao_band_8bit_sse2; }
 #endif
 }


### PR DESCRIPTION
Hello, 

it seems that on some processors invalid SSE instructions will be used.
If I run the decoder on an AMD Turion it crashes immediately with:

Error: SIGILL – Ungültiger Maschinenbefehl (Speicherabzug geschrieben)

This pull request try to fix the issues due avoiding of non-available instructions.

Regards,
 Olaf Schulz

========================================================================

Reason are the usage of SSSE3 or SSE4.1 instruction in functions which
are assumed as SSE2 compatible.
Following list contains the instruction for each of the failing functions.

It could be useful to restore older variants of the functions, if available.
(I had not checked if such functions are available.)

0. The detection for have_SSSE3 seems to be wrong. It returns true
  but the processor does not support it.

  Detected flags:
  MMX:1 SSE:1 SSE2:1 SSE3:1 SSSE3:1 SSE4a:0 SSE4_1:0 SSE4_2:0 AVX:0 AVX2:0
                            ^^^^^^^ wrong detection for AMD Turion, see Appendix A

  Solution: Use the correct register, ecx, not edx.
  int have_SSSE3  = !!(ecx & (1<< 9));


1. if (have_SSE2) { accel->sao_band_8 = sao_band_8bit_sse2; } (End of init_acceleration_functions_sse )

  Nemiver debugger stopped at
  x00007ffff7bb108e  <_Z18sao_band_8bit_sse2PhiPKhiiiiiiii+110>:  pshufb %xmm0,%xmm1

  pshufb is a SSSE3 command, which is not supported by the processor.

  Solution: Change line to (and rename function).
  if (have_SSSE3) { accel->sao_band_8 = sao_band_8bit_sse2; }


2. if (have_SSE2) { accel->put_hevc_qpel_8[0][0] = put_hevc_luma_direct_8_sse2; }

  Nemiver debugger stopped at
  0x00007ffff7ba89df  <_Z27put_hevc_luma_direct_8_sse2PslPKhliiS_+207>:  pinsrq $0x0,(%r11),%xmm0

  pinsrq is a SSE4.1 command
  Solution: Shift function into if(have_SSE4_1)-wrapper (and restore 
  older SSE2 variant if available.)


3. if (have_SSE2) { accel->put_hevc_epel_8    = put_hevc_chroma_direct_8_sse2; } 

  Nemiver debugger stopped at
  0x00007ffff7ba8b3f  <_Z29put_hevc_chroma_direct_8_sse2PslPKhliiiiS_+207>:  pinsrq $0x0,(%r11),%xmm0

  Solution: Like 2.


4. 98 #if HAVE_SSE4_1
   99   if (have_SSE2) { [...]

  Switch for put_pred_8_sse2 and put_bipred_8_sse2. Both function contain the
  instruction pextrd (SSE4.1): 

  Nemiver debugger stopped at
  0x00007ffff7ba7f6f  <_Z15put_pred_8_sse2PhlPKslii+447>:  pextrd $0x0,%xmm0,%r8d
  0x00007ffff7ba8107  <_Z17put_bipred_8_sse2PhlPKsS1_lii+375>:  pextrd $0x0,%xmm0,%r10d

  Solution: Like 2.


Appendix A)
  cat /proc/cpuinfo

processor	: 0
vendor_id	: AuthenticAMD
cpu family	: 15
model		: 36
model name	: AMD Turion(tm) 64 Mobile Technology MT-32
stepping	: 2
cpu MHz		: 800.000
cache size	: 512 KB
physical id	: 0
siblings	: 1
core id		: 0
cpu cores	: 1
apicid		: 0
initial apicid	: 0
fpu		: yes
fpu_exception	: yes
cpuid level	: 1
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 syscall nx mmxext fxsr_opt lm 3dnowext 3dnow rep_good nopl pni lahf_lm vmmcall
bogomips	: 1600.02
TLB size	: 1024 4K pages
clflush size	: 64
cache_alignment	: 64
address sizes	: 40 bits physical, 48 bits virtual
power management: ts fid vid ttp tm stc
