### PR TITLE
Visibility updates

### DIFF
--- a/acceleration-speed/Makefile.am
+++ b/acceleration-speed/Makefile.am
@@ -1,17 +1,21 @@
 
-bin_PROGRAMS = acceleration_speed
+bin_PROGRAMS =
 
 AM_CPPFLAGS = -I../libde265
 
-acceleration_speed_DEPENDENCIES = ../libde265/libde265.la
-acceleration_speed_CXXFLAGS =
-acceleration_speed_LDFLAGS =
-acceleration_speed_LDADD = ../libde265/libde265.la -lstdc++
-acceleration_speed_SOURCES = \
-  acceleration-speed.cc acceleration-speed.h \
-  dct.cc dct.h \
-  dct-scalar.cc dct-scalar.h
+if ENABLE_ACCELERATION_SPEED
+  bin_PROGRAMS += acceleration_speed
+
+  acceleration_speed_DEPENDENCIES = ../libde265/libde265.la
+  acceleration_speed_CXXFLAGS =
+  acceleration_speed_LDFLAGS =
+  acceleration_speed_LDADD = ../libde265/libde265.la -lstdc++
+  acceleration_speed_SOURCES = \
+    acceleration-speed.cc acceleration-speed.h \
+    dct.cc dct.h \
+    dct-scalar.cc dct-scalar.h
 
 if ENABLE_SSE_OPT
   acceleration_speed_SOURCES += dct-sse.cc
+endif
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -50,9 +50,7 @@ if test "x$GCC" = "xyes"; then
 fi
 changequote([,])dnl
 
-dnl gl_VISIBILITY
-dnl : In encoder branch, we still export all library symbols :
-HAVE_VISIBILITY=0
+AC_ARG_ENABLE([visibility], AS_HELP_STRING([--enable-visibility], [Enable visibility definitions.]), [gl_VISIBILITY], [HAVE_VISIBILITY=0])
 AM_CONDITIONAL([HAVE_VISIBILITY], [test "x$HAVE_VISIBILITY" != "x0"])
 
 # Checks for header files.
@@ -304,9 +302,15 @@ fi
 
 AC_ARG_ENABLE([dec265], AS_HELP_STRING([--disable-dec265], [Do not build dec265 decoder program.]))
 AC_ARG_ENABLE([sherlock265], AS_HELP_STRING([--disable-sherlock265], [Do not build sherlock265 visual inspection program.]))
+AC_ARG_ENABLE([hdrcopy], AS_HELP_STRING([--disable-hdrcopy], [Do not build hdrcopy decoder program.]))
+AC_ARG_ENABLE([enc265], AS_HELP_STRING([--disable-enc265], [Do not build enc265 encoder program.]))
+AC_ARG_ENABLE([acceleration_speed], AS_HELP_STRING([--disable-acceleration_speed], [Do not build acceleration_speed test program.]))
 
 if eval "test x$enable_dec265 = x"      ; then enable_dec265=yes ; fi
 if eval "test x$enable_sherlock265 = x" ; then enable_sherlock265=yes ; fi
+if eval "test x$enable_hdrcopy = x"     ; then enable_hdrcopy=yes ; fi
+if eval "test x$enable_enc265 = x"      ; then enable_enc265=yes ; fi
+if eval "test x$enable_acceleration_speed = x" ; then enable_acceleration_speed=yes ; fi
 
 if eval "test x$enable_dec265 = xyes" || eval "test x$enable_sherlock265 = xyes" ; then
    PKG_CHECK_MODULES([VIDEOGFX], [libvideogfx],
@@ -379,6 +383,9 @@ fi
 
 AM_CONDITIONAL([ENABLE_DEC265], [test "x$enable_dec265" != "xno"])
 AM_CONDITIONAL([ENABLE_SHERLOCK265], [test "x$enable_sherlock265" != "xno"])
+AM_CONDITIONAL([ENABLE_HDRCOPY], [test "x$enable_hdrcopy" != "xno"])
+AM_CONDITIONAL([ENABLE_ENC265], [test "x$enable_enc265" != "xno"])
+AM_CONDITIONAL([ENABLE_ACCELERATION_SPEED], [test "x$enable_acceleration_speed" != "xno"])
 
 
 # --- output configuration results ---
@@ -387,6 +394,9 @@ AC_MSG_NOTICE([---------------------------------------])
 AC_MSG_NOTICE([Processor acceleration: $MSG_ACCELERATION_OPTION])
 AC_MSG_NOTICE([Building dec265 example: $enable_dec265])
 AC_MSG_NOTICE([Building sherlock265 example: $enable_sherlock265])
+AC_MSG_NOTICE([Building hdrcopy example: $enable_hdrcopy])
+AC_MSG_NOTICE([Building enc265 example: $enable_enc265])
+AC_MSG_NOTICE([Building acceleration_speed example: $enable_acceleration_speed])
 AC_MSG_NOTICE([---------------------------------------])
 
 AC_CONFIG_FILES([Makefile])

--- a/dec265/Makefile.am
+++ b/dec265/Makefile.am
@@ -1,5 +1,5 @@
 
-bin_PROGRAMS = dec265 hdrcopy
+bin_PROGRAMS = dec265
 
 AM_CPPFLAGS = -I../libde265
 
@@ -9,11 +9,15 @@ dec265_LDFLAGS =
 dec265_LDADD = ../libde265/libde265.la -lstdc++
 dec265_SOURCES = dec265.cc
 
-hdrcopy_DEPENDENCIES = ../libde265/libde265.la
-hdrcopy_CXXFLAGS =
-hdrcopy_LDFLAGS =
-hdrcopy_LDADD = ../libde265/libde265.la -lstdc++
-hdrcopy_SOURCES = hdrcopy.cc
+if ENABLE_HDRCOPY
+  bin_PROGRAMS += hdrcopy
+
+  hdrcopy_DEPENDENCIES = ../libde265/libde265.la
+  hdrcopy_CXXFLAGS =
+  hdrcopy_LDFLAGS =
+  hdrcopy_LDADD = ../libde265/libde265.la -lstdc++
+  hdrcopy_SOURCES = hdrcopy.cc
+endif
 
 if HAVE_VIDEOGFX
   dec265_CXXFLAGS += $(VIDEOGFX_CFLAGS)

--- a/enc265/Makefile.am
+++ b/enc265/Makefile.am
@@ -1,17 +1,21 @@
 
-bin_PROGRAMS = enc265
+bin_PROGRAMS =
 
 AM_CPPFLAGS = -I../libde265
 
-enc265_DEPENDENCIES = ../libde265/libde265.la
-enc265_CXXFLAGS =
-enc265_LDFLAGS =
-enc265_LDADD = ../libde265/libde265.la -lstdc++
-enc265_SOURCES = enc265.cc image-io-png.cc image-io-png.h
+if ENABLE_ENC265
+  bin_PROGRAMS += enc265
+
+  enc265_DEPENDENCIES = ../libde265/libde265.la
+  enc265_CXXFLAGS =
+  enc265_LDFLAGS =
+  enc265_LDADD = ../libde265/libde265.la -lstdc++
+  enc265_SOURCES = enc265.cc image-io-png.cc image-io-png.h
 
 if HAVE_VIDEOGFX
   enc265_CXXFLAGS += $(VIDEOGFX_CFLAGS)
   enc265_LDFLAGS += $(VIDEOGFX_LIBS)
+endif
 endif
 
 EXTRA_DIST = \

--- a/libde265/encoder/Makefile.am
+++ b/libde265/encoder/Makefile.am
@@ -10,6 +10,18 @@ libde265_encoder_la_SOURCES = \
   encpicbuf.h encpicbuf.cc \
   sop.h sop.cc
 
+libde265_encoder_la_CFLAGS = \
+  $(CFLAG_VISIBILITY) \
+  -DLIBDE265_EXPORTS
+libde265_encoder_la_CXXFLAGS += \
+  $(CFLAG_VISIBILITY) \
+  -DLIBDE265_EXPORTS
+
+if HAVE_VISIBILITY
+ libde265_encoder_la_CFLAGS += -DHAVE_VISIBILITY
+ libde265_encoder_la_CXXFLAGS += -DHAVE_VISIBILITY
+endif
+
 SUBDIRS=algo
 libde265_encoder_la_LIBADD = algo/libde265_encoder_algo.la
 

--- a/libde265/encoder/algo/Makefile.am
+++ b/libde265/encoder/algo/Makefile.am
@@ -17,5 +17,13 @@ libde265_encoder_algo_la_SOURCES = \
   tb-rateestim.h tb-rateestim.cc \
   pb-mv.h pb-mv.cc
 
+libde265_encoder_algo_la_CXXFLAGS += \
+  $(CFLAG_VISIBILITY) \
+  -DLIBDE265_EXPORTS
+
+if HAVE_VISIBILITY
+ libde265_encoder_algo_la_CXXFLAGS += -DHAVE_VISIBILITY
+endif
+
 EXTRA_DIST = \
   CMakeLists.txt


### PR DESCRIPTION
Allow to enable visibility definitions through a "configure" option.

Also add options to disable building of various commandline tools that don't work if symbols get hidden in "libde265.so".

This will help removing some patches in the packaging later...