### PR TITLE
Bump numeric version to 2.0.0 and SO version to 1.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,8 @@ project (libde265)
 cmake_minimum_required (VERSION 2.8.8)
 
 # The version number.
-set (NUMERIC_VERSION 0x01000000)
-set (PACKAGE_VERSION 1.0.0)
+set (NUMERIC_VERSION 0x02000000)
+set (PACKAGE_VERSION 2.0.0)
 
 include (${CMAKE_ROOT}/Modules/CheckCCompilerFlag.cmake)
 include (${CMAKE_ROOT}/Modules/CheckIncludeFile.cmake)

--- a/configure.ac
+++ b/configure.ac
@@ -2,15 +2,15 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.68])
-AC_INIT([libde265], [1.0.2], [farin@struktur.de])
+AC_INIT([libde265], [2.0.0], [farin@struktur.de])
 AC_CONFIG_SRCDIR([libde265/de265.cc])
 AC_CONFIG_HEADERS([config.h])
 
-NUMERIC_VERSION=0x01000200 # Numeric representation of the version (A.B.C[.D] = 0xAABBCCDD)
+NUMERIC_VERSION=0x02000000 # Numeric representation of the version (A.B.C[.D] = 0xAABBCCDD)
 AC_SUBST(NUMERIC_VERSION)
 
-LIBDE265_CURRENT=0
-LIBDE265_REVISION=10
+LIBDE265_CURRENT=1
+LIBDE265_REVISION=0
 LIBDE265_AGE=0
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The next version will be "libde265 2.0.0", so also use next major version for library.