### PR TITLE
Use newer version of QEMU for ARM tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ matrix:
 before_install:
   - sh -c "if [ ! -z '$DECODESTREAMS' ]; then sudo add-apt-repository -y ppa:strukturag/libde265; fi"
   - sudo add-apt-repository -y ppa:kalakris/cmake
+  - sh -c "if ( echo '$HOST' | grep -q '^arm' ); then sudo add-apt-repository -y ppa:linaro-maintainers/tools; fi"
   - sudo apt-get update -qq
   - sh -c "if [ -z '$HOST' ]; then sudo apt-get install -qq valgrind libsdl-dev libqt4-dev libswscale-dev; fi"
   - sh -c "if [ -z '$HOST' ] && [ -z '$DECODESTREAMS' ]; then sudo apt-get install -qq devscripts; fi"
@@ -86,7 +87,7 @@ script:
   - sh -c "if [ ! -z "$WINE" ]; then WINEPREFIX=`pwd`/$WINE WINEPATH=/usr/lib/gcc/$HOST/4.6/ $WINE ./dec265/dec265.exe -q -c ./libde265-data/RandomAccess/paris-ra-wpp.bin; fi"
   - sh -c "if [ ! -z "$WINE" ]; then WINEPREFIX=`pwd`/$WINE WINEPATH=/usr/lib/gcc/$HOST/4.6/ $WINE ./dec265/dec265.exe -t 4 -q -c ./libde265-data/RandomAccess/paris-ra-wpp.bin; fi"
   - sh -c "if ( echo '$HOST' | grep -q '^arm' ); then LD_LIBRARY_PATH=`pwd`/libde265/.libs/ qemu-arm -L /usr/$HOST ./dec265/.libs/dec265 -q -c ./libde265-data/IDR-only/paris-352x288-intra.bin; fi"
-  #- sh -c "if ( echo '$HOST' | grep -q '^arm' ); then LD_LIBRARY_PATH=`pwd`/libde265/.libs/ qemu-arm -L /usr/$HOST ./dec265/.libs/dec265 -t 4 -q -c ./libde265-data/IDR-only/paris-352x288-intra.bin; fi"
-  #- sh -c "if ( echo '$HOST' | grep -q '^arm' ); then LD_LIBRARY_PATH=`pwd`/libde265/.libs/ qemu-arm -L /usr/$HOST ./dec265/.libs/dec265 -q -c ./libde265-data/RandomAccess/paris-ra-wpp.bin; fi"
-  #- sh -c "if ( echo '$HOST' | grep -q '^arm' ); then LD_LIBRARY_PATH=`pwd`/libde265/.libs/ qemu-arm -L /usr/$HOST ./dec265/.libs/dec265 -t 4 -q -c ./libde265-data/RandomAccess/paris-ra-wpp.bin; fi"
+  - sh -c "if ( echo '$HOST' | grep -q '^arm' ); then LD_LIBRARY_PATH=`pwd`/libde265/.libs/ qemu-arm -L /usr/$HOST ./dec265/.libs/dec265 -t 4 -q -c ./libde265-data/IDR-only/paris-352x288-intra.bin; fi"
+  - sh -c "if ( echo '$HOST' | grep -q '^arm' ); then LD_LIBRARY_PATH=`pwd`/libde265/.libs/ qemu-arm -L /usr/$HOST ./dec265/.libs/dec265 -q -c ./libde265-data/RandomAccess/paris-ra-wpp.bin; fi"
+  - sh -c "if ( echo '$HOST' | grep -q '^arm' ); then LD_LIBRARY_PATH=`pwd`/libde265/.libs/ qemu-arm -L /usr/$HOST ./dec265/.libs/dec265 -t 4 -q -c ./libde265-data/RandomAccess/paris-ra-wpp.bin; fi"
   - sh -c "if [ ! -z '$DECODESTREAMS' ]; then python scripts/decodestreams.py $THREADING /var/lib/libde265-teststreams; fi"


### PR DESCRIPTION
This should fix the crashes we get with the current ARM testing.

See https://travis-ci.org/strukturag/libde265/jobs/192976043 for an example build.