### PR TITLE
Fixes for building under Windows.

### DIFF
--- a/libde265/deblock.cc
+++ b/libde265/deblock.cc
@@ -143,7 +143,7 @@ bool derive_edgeFlags_CTBRow(de265_image* img, int ctby)
   int cb_y_start = ( ctby    << sps.Log2CtbSizeY) >> sps.Log2MinCbSizeY;
   int cb_y_end   = ((ctby+1) << sps.Log2CtbSizeY) >> sps.Log2MinCbSizeY;
 
-  cb_y_end = std::min(cb_y_end, sps.PicHeightInMinCbsY);
+  cb_y_end = libde265_min(cb_y_end, sps.PicHeightInMinCbsY);
 
   for (int cb_y=cb_y_start;cb_y<cb_y_end;cb_y++)
     for (int cb_x=0;cb_x<img->get_sps().PicWidthInMinCbsY;cb_x++)
@@ -936,7 +936,7 @@ void thread_task_deblock_CTBRow::work()
   if (vertical) {
     // pass 1: vertical
 
-    int CtbRow = std::min(ctb_y+1 , img->get_sps().PicHeightInCtbsY-1);
+    int CtbRow = libde265_min(ctb_y+1 , img->get_sps().PicHeightInCtbsY-1);
     img->wait_for_progress(this, rightCtb,CtbRow, CTB_PROGRESS_PREFILTER);
   }
   else {

--- a/libde265/decctx.cc
+++ b/libde265/decctx.cc
@@ -482,8 +482,8 @@ void decoder_context::init_thread_context(thread_context* tctx)
     int x = ((ctbX+1) << sps.Log2CtbSizeY)-1;
     int y = ((ctbY+1) << sps.Log2CtbSizeY)-1;
 
-    x = std::min(x,sps.pic_width_in_luma_samples-1);
-    y = std::min(y,sps.pic_height_in_luma_samples-1);
+    x = libde265_min(x,sps.pic_width_in_luma_samples-1);
+    y = libde265_min(y,sps.pic_height_in_luma_samples-1);
 
     //printf("READ QPY: %d %d -> %d (should %d)\n",x,y,imgunit->img->get_QPY(x,y), tc.currentQPY);
 
@@ -2156,8 +2156,8 @@ int decoder_context::change_framerate(int more)
   assert(more>=-1 && more<=1);
 
   goal_HighestTid += more;
-  goal_HighestTid = std::max(goal_HighestTid, 0);
-  goal_HighestTid = std::min(goal_HighestTid, highestTid);
+  goal_HighestTid = libde265_max(goal_HighestTid, 0);
+  goal_HighestTid = libde265_min(goal_HighestTid, highestTid);
 
   framerate_ratio = framedrop_tid_index[goal_HighestTid];
 

--- a/libde265/encoder/algo/tb-intrapredmode.cc
+++ b/libde265/encoder/algo/tb-intrapredmode.cc
@@ -303,7 +303,7 @@ Algo_TB_IntraPredMode_MinResidual::analyze(encoder_context* ectx,
     *tb->downPtr = tb;
 
     enum IntraPredMode intraMode;
-    float minDistortion = std::numeric_limits<float>::max();
+    float minDistortion = (std::numeric_limits<float>::max)();
 
     assert(nPredModesEnabled()>=1);
 
@@ -413,7 +413,7 @@ Algo_TB_IntraPredMode_FastBrute::analyze(encoder_context* ectx,
   selectIntraPredMode |= (cb->PredMode==MODE_INTRA && cb->PartMode==PART_NxN   && TrafoDepth==1);
 
   if (selectIntraPredMode) {
-    float minCost = std::numeric_limits<float>::max();
+    float minCost = (std::numeric_limits<float>::max)();
     int   minCostIdx=0;
     float minCandCost;
 
@@ -453,7 +453,7 @@ Algo_TB_IntraPredMode_FastBrute::analyze(encoder_context* ectx,
         //printf("%d -> %f\n",i,distortions[i].second);
       }
 
-    int keepNBest=std::min((int)mParams.keepNBest, (int)distortions.size());
+    int keepNBest=libde265_min((int)mParams.keepNBest, (int)distortions.size());
     distortions.resize(keepNBest);
     distortions.push_back(std::make_pair((enum IntraPredMode)candidates[0],0));
     distortions.push_back(std::make_pair((enum IntraPredMode)candidates[1],0));

--- a/libde265/encoder/encoder-syntax.cc
+++ b/libde265/encoder/encoder-syntax.cc
@@ -511,7 +511,7 @@ int blamain()
     {
       printf("%d: ",level);
 
-      int prefixPart = std::min(TRMax, level);
+      int prefixPart = libde265_min(TRMax, level);
 
       // code TR prefix
 
@@ -543,7 +543,7 @@ static void encode_coeff_abs_level_remaining(encoder_context* ectx,
   logtrace(LogSlice,"# encode_coeff_abs_level_remaining = %d\n",level);
 
   int cTRMax = 4<<cRiceParam;
-  int prefixPart = std::min(level, cTRMax);
+  int prefixPart = libde265_min(level, cTRMax);
 
   // --- code prefix with TR ---
 

--- a/libde265/image.cc
+++ b/libde265/image.cc
@@ -246,7 +246,7 @@ de265_error de265_image::alloc_image(int w,int h, enum de265_chroma c,
                 will not be freed. */
 
   ID = s_next_image_ID++;
-  removed_at_picture_id = std::numeric_limits<int32_t>::max();
+  removed_at_picture_id = (std::numeric_limits<int32_t>::max)();
 
   decctx = dctx;
   encctx = ectx;


### PR DESCRIPTION
This patch fixes issues with the `min` and `max` macros under Windows.