### PR TITLE
Use libde265_min and libde265_max

### DIFF
--- a/libde265/deblock.cc
+++ b/libde265/deblock.cc
@@ -143,7 +143,7 @@ bool derive_edgeFlags_CTBRow(de265_image* img, int ctby)
   int cb_y_start = ( ctby    << sps.Log2CtbSizeY) >> sps.Log2MinCbSizeY;
   int cb_y_end   = ((ctby+1) << sps.Log2CtbSizeY) >> sps.Log2MinCbSizeY;
 
-  cb_y_end = std::min(cb_y_end, sps.PicHeightInMinCbsY);
+  cb_y_end = libde265_min(cb_y_end, sps.PicHeightInMinCbsY);
 
   for (int cb_y=cb_y_start;cb_y<cb_y_end;cb_y++)
     for (int cb_x=0;cb_x<img->get_sps().PicWidthInMinCbsY;cb_x++)
@@ -936,7 +936,7 @@ void thread_task_deblock_CTBRow::work()
   if (vertical) {
     // pass 1: vertical
 
-    int CtbRow = std::min(ctb_y+1 , img->get_sps().PicHeightInCtbsY-1);
+    int CtbRow = libde265_min(ctb_y+1 , img->get_sps().PicHeightInCtbsY-1);
     img->wait_for_progress(this, rightCtb,CtbRow, CTB_PROGRESS_PREFILTER);
   }
   else {

--- a/libde265/decctx.cc
+++ b/libde265/decctx.cc
@@ -2158,7 +2158,7 @@ int decoder_context::change_framerate(int more)
   assert(more>=-1 && more<=1);
 
   goal_HighestTid += more;
-  goal_HighestTid = std::max(goal_HighestTid, 0);
+  goal_HighestTid = libde265_max(goal_HighestTid, 0);
   goal_HighestTid = libde265_min(goal_HighestTid, highestTid);
 
   framerate_ratio = framedrop_tid_index[goal_HighestTid];

--- a/libde265/decctx.cc
+++ b/libde265/decctx.cc
@@ -482,8 +482,8 @@ void decoder_context::init_thread_context(thread_context* tctx)
     int x = ((ctbX+1) << sps.Log2CtbSizeY)-1;
     int y = ((ctbY+1) << sps.Log2CtbSizeY)-1;
 
-    x = std::min(x,sps.pic_width_in_luma_samples-1);
-    y = std::min(y,sps.pic_height_in_luma_samples-1);
+    x = libde265_min(x,sps.pic_width_in_luma_samples-1);
+    y = libde265_min(y,sps.pic_height_in_luma_samples-1);
 
     //printf("READ QPY: %d %d -> %d (should %d)\n",x,y,imgunit->img->get_QPY(x,y), tc.currentQPY);
 
@@ -2159,7 +2159,7 @@ int decoder_context::change_framerate(int more)
 
   goal_HighestTid += more;
   goal_HighestTid = std::max(goal_HighestTid, 0);
-  goal_HighestTid = std::min(goal_HighestTid, highestTid);
+  goal_HighestTid = libde265_min(goal_HighestTid, highestTid);
 
   framerate_ratio = framedrop_tid_index[goal_HighestTid];
 

--- a/libde265/encoder/algo/tb-intrapredmode.cc
+++ b/libde265/encoder/algo/tb-intrapredmode.cc
@@ -454,7 +454,7 @@ Algo_TB_IntraPredMode_FastBrute::analyze(encoder_context* ectx,
         //printf("%d -> %f\n",i,distortions[i].second);
       }
 
-    int keepNBest=std::min((int)mParams.keepNBest, (int)distortions.size());
+    int keepNBest=libde265_min((int)mParams.keepNBest, (int)distortions.size());
     distortions.resize(keepNBest);
     distortions.push_back(std::make_pair((enum IntraPredMode)candidates[0],0));
     distortions.push_back(std::make_pair((enum IntraPredMode)candidates[1],0));

--- a/libde265/encoder/encoder-syntax.cc
+++ b/libde265/encoder/encoder-syntax.cc
@@ -512,7 +512,7 @@ int blamain()
     {
       printf("%d: ",level);
 
-      int prefixPart = std::min(TRMax, level);
+      int prefixPart = libde265_min(TRMax, level);
 
       // code TR prefix
 
@@ -544,7 +544,7 @@ static void encode_coeff_abs_level_remaining(encoder_context* ectx,
   logtrace(LogSlice,"# encode_coeff_abs_level_remaining = %d\n",level);
 
   int cTRMax = 4<<cRiceParam;
-  int prefixPart = std::min(level, cTRMax);
+  int prefixPart = libde265_min(level, cTRMax);
 
   // --- code prefix with TR ---
 


### PR DESCRIPTION
This PR changes `std::min` to `libde265_min` and `std::max` to `libde265_max`.  We use this library inside the @ImageMagick project and our build fails without these changes.