### PR TITLE
Added parentheses.

### DIFF
--- a/libde265/encoder/algo/tb-intrapredmode.cc
+++ b/libde265/encoder/algo/tb-intrapredmode.cc
@@ -304,7 +304,7 @@ Algo_TB_IntraPredMode_MinResidual::analyze(encoder_context* ectx,
     *tb->downPtr = tb;
 
     enum IntraPredMode intraMode;
-    float minDistortion = std::numeric_limits<float>::max();
+    float minDistortion = (std::numeric_limits<float>::max)();
 
     assert(nPredModesEnabled()>=1);
 
@@ -414,7 +414,7 @@ Algo_TB_IntraPredMode_FastBrute::analyze(encoder_context* ectx,
   selectIntraPredMode |= (cb->PredMode==MODE_INTRA && cb->PartMode==PART_NxN   && TrafoDepth==1);
 
   if (selectIntraPredMode) {
-    float minCost = std::numeric_limits<float>::max();
+    float minCost = (std::numeric_limits<float>::max)();
     int   minCostIdx=0;
     float minCandCost;
 

--- a/libde265/encoder/encoder-core.cc
+++ b/libde265/encoder/encoder-core.cc
@@ -211,7 +211,7 @@ double encode_image(encoder_context* ectx,
 
         enc_cb* cb = algo.getAlgoCTBQScale()->analyze(ectx,ctxModel, x0,y0);
 #else
-        float minCost = std::numeric_limits<float>::max();
+        float minCost = (std::numeric_limits<float>::max)();
         int bestQ = 0;
         int qp = ectx->params.constant_QP;
 

--- a/libde265/image.cc
+++ b/libde265/image.cc
@@ -247,7 +247,7 @@ de265_error de265_image::alloc_image(int w,int h, enum de265_chroma c,
                 will not be freed. */
 
   ID = s_next_image_ID++;
-  removed_at_picture_id = std::numeric_limits<int32_t>::max();
+  removed_at_picture_id = (std::numeric_limits<int32_t>::max)();
 
   decctx = dctx;
   //encctx = ectx;


### PR DESCRIPTION
This PR adds parentheses to prevent the use of the `max` define. We use this library inside the @ImageMagick project and our build fails without these changes.