### PR TITLE
Return error if vps_num_hrd_parameters is below zero.

### DIFF
--- a/libde265/vps.cc
+++ b/libde265/vps.cc
@@ -185,7 +185,7 @@ if (layer[i].vps_max_dec_pic_buffering == UVLC_ERROR ||
       vps_num_ticks_poc_diff_one = get_uvlc(reader)+1;
       vps_num_hrd_parameters     = get_uvlc(reader);
 
-      if (vps_num_hrd_parameters >= 1024) {
+      if (vps_num_hrd_parameters < 0 || vps_num_hrd_parameters >= 1024) {
         errqueue->add_warning(DE265_ERROR_CODED_PARAMETER_OUT_OF_RANGE, false);
         return DE265_ERROR_CODED_PARAMETER_OUT_OF_RANGE;
       }


### PR DESCRIPTION
This issue was found with the Google OSS-fuzz tooling. If `vps_num_hrd_parameters` is below zero both `hrd_layer_set_idx.resize` and `cprms_present_flag.resize` will be called with a negative value.