### PR TITLE
Add support for hrd parameters in Video usability information

### DIFF
--- a/libde265/vui.cc
+++ b/libde265/vui.cc
@@ -223,6 +223,7 @@ de265_error video_usability_information::hrd_parameters(error_queue* errqueue, b
       }
     }
   }
+  return DE265_OK;
 }
 
 de265_error video_usability_information::read(error_queue* errqueue, bitreader* br,

--- a/libde265/vui.h
+++ b/libde265/vui.h
@@ -46,7 +46,8 @@ class video_usability_information
 {
  public:
   video_usability_information();
-
+  
+  de265_error hrd_parameters(error_queue*, bitreader*, const seq_parameter_set*);
   de265_error read(error_queue*, bitreader*, const seq_parameter_set*);
   void dump(int fd) const;
 
@@ -106,9 +107,30 @@ class video_usability_information
   // --- hrd parameters ---
 
   bool     vui_hrd_parameters_present_flag;
-  //hrd_parameters vui_hrd_parameters;
-
-
+  bool     nal_hrd_parameters_present_flag;
+  bool     vcl_hrd_parameters_present_flag;
+  bool     sub_pic_hrd_params_present_flag;
+  uint32_t tick_divisor_minus2;
+  uint32_t du_cpb_removal_delay_increment_length_minus1;
+  bool     sub_pic_cpb_params_in_pic_timing_sei_flag;
+  uint32_t dpb_output_delay_du_length_minus1;
+  uint32_t bit_rate_scale;
+  uint32_t cpb_size_scale;
+  uint32_t cpb_size_du_scale;
+  uint32_t initial_cpb_removal_delay_length_minus1;
+  uint32_t au_cpb_removal_delay_length_minus1;
+  uint32_t dpb_output_delay_length_minus1;
+  bool     fixed_pic_rate_general_flag[7];
+  bool     fixed_pic_rate_within_cvs_flag[7];
+  bool     low_delay_hrd_flag[7];
+  uint32_t cpb_cnt_minus1[7];
+  uint32_t elemental_duration_in_tc_minus1[7];
+  uint32_t bit_rate_value_minus1[7][32][2];
+  uint32_t cpb_size_value_minus1[7][32][2];
+  uint32_t cpb_size_du_value_minus1[7][32][2];
+  uint32_t bit_rate_du_value_minus1[7][32][2];
+  bool     cbr_flag[7][32][2];
+  
   // --- bitstream restriction ---
 
   bool bitstream_restriction_flag;


### PR DESCRIPTION
Correctly parse the vui_timing_info section in vui_parameters( ) including the vui_hrd_parameters according to Rec. ITU-T H.265 v3 (04/2015).
This was  unsupported yet, and the following bitstream_restriction section was not parsed if vui_hrd_parameters were present.