### PR TITLE
warning: converting to non-pointer type 'DWORD'

### DIFF
--- a/libde265/threads.cc
+++ b/libde265/threads.cc
@@ -210,7 +210,7 @@ static THREAD_RESULT worker_thread(THREAD_PARAM pool_ptr)
 
     if (pool->stopped) {
       de265_mutex_unlock(&pool->mutex);
-      return NULL;
+      return 0;
     }
 
 
@@ -238,7 +238,7 @@ static THREAD_RESULT worker_thread(THREAD_PARAM pool_ptr)
   }
   de265_mutex_unlock(&pool->mutex);
 
-  return NULL;
+  return 0;
 }
 
 

--- a/libde265/threads.cc
+++ b/libde265/threads.cc
@@ -210,9 +210,13 @@ static THREAD_RESULT worker_thread(THREAD_PARAM pool_ptr)
 
     if (pool->stopped) {
       de265_mutex_unlock(&pool->mutex);
-      return 0;
-    }
 
+#ifdef _WIN32
+      return 0UL;
+#else
+      return NULL;
+#endif
+    }
 
     // get a task
 
@@ -224,7 +228,6 @@ static THREAD_RESULT worker_thread(THREAD_PARAM pool_ptr)
     //printblks(pool);
 
     de265_mutex_unlock(&pool->mutex);
-
 
     // execute the task
 
@@ -238,7 +241,11 @@ static THREAD_RESULT worker_thread(THREAD_PARAM pool_ptr)
   }
   de265_mutex_unlock(&pool->mutex);
 
-  return 0;
+#ifdef _WIN32
+  return 0UL;
+#else
+  return NULL;
+#endif
 }
 
 


### PR DESCRIPTION
threads.cc:213:14: warning: converting to non-pointer type 'DWORD' {aka 'long unsigned int'} from NULL [-Wconversion-null]
  213 |       return NULL;
      |              ^~~~
threads.cc:241:10: warning: converting to non-pointer type 'DWORD' {aka 'long unsigned int'} from NULL [-Wconversion-null]
  241 |   return NULL;
      |          ^~~~