### PR TITLE
Import "en265.h" to get correct name mangling of exported functions.

### DIFF
--- a/libde265/image.cc
+++ b/libde265/image.cc
@@ -20,6 +20,7 @@
 
 #include "image.h"
 #include "decctx.h"
+#include "en265.h"
 
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Without the header, "C++" name mangling will be used instead of the required "C" names.

@farindk just noticed this when updating the packages, looks like it was introduced in https://github.com/strukturag/libde265/commit/8c0626b6dea536d60af66d73fb79eb87b25a56c8#diff-7653bd05d0c3e245189a8fe64de6b808