### PR TITLE
Fix installing de265-version.h with CMake

### DIFF
--- a/libde265/CMakeLists.txt
+++ b/libde265/CMakeLists.txt
@@ -43,7 +43,6 @@ set (libde265_headers
   bitstream.h
   cabac.h
   configparam.h
-  de265-version.h
   contextmodel.h
   de265.h
   deblock.h


### PR DESCRIPTION
File `de265-version.h` cannot be properly installed in out-of-source builds because it is listed in `libde265_headers`.

Reproducing:
```shell
mkdir build && cd build && cmake -DCMAKE_INSTALL_PREFIX=/tmp/libde265-inst .. && make && make install
```