### PR TITLE
Fix compilation on Windows with /std:c++latest

### DIFF
--- a/libde265/util.h
+++ b/libde265/util.h
@@ -65,7 +65,7 @@
 #define ALIGNED_4( var )  LIBDE265_DECLARE_ALIGNED( var, 4 )
 
 // C++11 specific features
-#if !__clang__ && (defined(_MSC) && _MSC < 1900 || __GNUC__ && GCC_VERSION < 40600)
+#if !__clang__ && (defined(_MSC_VER) && _MSC_VER < 1900 || __GNUC__ && GCC_VERSION < 40600)
 #define FOR_LOOP(type, var, list)   for each (type var in list)
 #undef FOR_LOOP_AUTO_SUPPORT
 #else

--- a/libde265/util.h
+++ b/libde265/util.h
@@ -65,7 +65,7 @@
 #define ALIGNED_4( var )  LIBDE265_DECLARE_ALIGNED( var, 4 )
 
 // C++11 specific features
-#if defined(_MSC_VER) || (!__clang__ && __GNUC__ && GCC_VERSION < 40600)
+#if !__clang__ && (defined(_MSC) && _MSC < 1900 || __GNUC__ && GCC_VERSION < 40600)
 #define FOR_LOOP(type, var, list)   for each (type var in list)
 #undef FOR_LOOP_AUTO_SUPPORT
 #else


### PR DESCRIPTION
When compiling libde265 on Windows using MSVC 2019 and the latest C++ standard preview (which is C++20), I get the following error:
`error C4496: nonstandard extension 'for each' used: replace with ranged-for statement`
The similar issue arises when using clang-cl.

Actually, MSVC supports ranged-for statement since MSVC 2012, and has full C++11 support for `auto` since MSVC 2015 ([reference](https://docs.microsoft.com/en-us/previous-versions/hh567368(v=vs.140))); `_MSC_VER` version code for MSVC 2015 is `1900`. Hence the easy fix.