### PR TITLE
Refactor AppVeyor configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,43 +1,35 @@
 # stats available at
 # https://ci.appveyor.com/project/strukturag/libde265
-version: 1.0.{build}
-
-os:
-  - Windows Server 2012 R2
+image: Visual Studio 2019
+configuration: Release
 
 environment:
   matrix:
-    - GENERATOR: "Visual Studio 11 2012"
-    - GENERATOR: "Visual Studio 12 2013"
+  - arch: x64
 
-platform:
-  - x86
-  - x64
+install:
+  - git clone --depth 1 https://github.com/strukturag/libde265-data.git
 
-configuration:
-  - Debug
+before_build:
+  - mkdir build
+  - cd build
+  - cmake .. -A %arch%
 
 build:
   verbosity: normal
 
-install:
-  - git clone https://github.com/strukturag/libde265-data.git
-
-build_script:
-  - ps: if($env:PLATFORM -eq "x64") { $env:CMAKE_GEN_SUFFIX=" Win64" }
-  - cmake "-G%GENERATOR%%CMAKE_GEN_SUFFIX%" -H. -Bbuild
-  - cmake --build build --config %CONFIGURATION%
-
 before_test:
-  - copy /y build\dec265\%CONFIGURATION%\dec265.exe build
-  - copy /y build\enc265\%CONFIGURATION%\enc265.exe build
-  - copy /y build\libde265\%CONFIGURATION%\libde265.dll build
+  - copy /y dec265\%CONFIGURATION%\dec265.exe .
+  - copy /y enc265\%CONFIGURATION%\enc265.exe .
+  - copy /y libde265\%CONFIGURATION%\libde265.dll .
 
 test_script:
-  - build\dec265.exe -q -c -f 100 libde265-data\IDR-only\paris-352x288-intra.bin
-  - build\dec265.exe -t 4 -q -c -f 100 libde265-data\IDR-only\paris-352x288-intra.bin
-  - build\dec265.exe -q -c -f 100 libde265-data\RandomAccess\paris-ra-wpp.bin
-  - build\dec265.exe -t 4 -q -c -f 100 libde265-data\RandomAccess\paris-ra-wpp.bin
+  - dec265.exe -q -c -f 100 ..\libde265-data\IDR-only\paris-352x288-intra.bin
+  - dec265.exe -t 4 -q -c -f 100 ..\libde265-data\IDR-only\paris-352x288-intra.bin
+  - dec265.exe -q -c -f 100 ..\libde265-data\RandomAccess\paris-ra-wpp.bin
+  - dec265.exe -t 4 -q -c -f 100 ..\libde265-data\RandomAccess\paris-ra-wpp.bin
 
 artifacts:
   - path: build
+  - path: build\**\Release\*.exe
+  - path: build\**\Release\*.dll

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,10 @@
 image: Visual Studio 2019
 configuration: Release
 
+matrix:
+  allow_failures:
+    - arch: arm64
+
 environment:
   matrix:
   - arch: x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ configuration: Release
 environment:
   matrix:
   - arch: x64
+  - arch: arm64
 
 install:
   - git clone --depth 1 https://github.com/strukturag/libde265-data.git
@@ -18,16 +19,20 @@ before_build:
 build:
   verbosity: normal
 
-before_test:
-  - copy /y dec265\%CONFIGURATION%\dec265.exe .
-  - copy /y enc265\%CONFIGURATION%\enc265.exe .
-  - copy /y libde265\%CONFIGURATION%\libde265.dll .
-
-test_script:
-  - dec265.exe -q -c -f 100 ..\libde265-data\IDR-only\paris-352x288-intra.bin
-  - dec265.exe -t 4 -q -c -f 100 ..\libde265-data\IDR-only\paris-352x288-intra.bin
-  - dec265.exe -q -c -f 100 ..\libde265-data\RandomAccess\paris-ra-wpp.bin
-  - dec265.exe -t 4 -q -c -f 100 ..\libde265-data\RandomAccess\paris-ra-wpp.bin
+for:
+  -
+    matrix:
+      only:
+        - arch: x64
+    before_test:
+      - copy /y dec265\Release\dec265.exe .
+      - copy /y enc265\Release\enc265.exe .
+      - copy /y libde265\Release\libde265.dll .
+    test_script:
+      - dec265.exe -q -c -f 100 ..\libde265-data\IDR-only\paris-352x288-intra.bin
+      - dec265.exe -t 4 -q -c -f 100 ..\libde265-data\IDR-only\paris-352x288-intra.bin
+      - dec265.exe -q -c -f 100 ..\libde265-data\RandomAccess\paris-ra-wpp.bin
+      - dec265.exe -t 4 -q -c -f 100 ..\libde265-data\RandomAccess\paris-ra-wpp.bin
 
 artifacts:
   - path: build


### PR DESCRIPTION
This PR refactors the AppVeyor configuration. Since it's quite a large PR, I split is up into 3 commits:

- Refactor AppVeyor configuration
  - Updates environment to the [Visual Studio 2019](https://www.appveyor.com/docs/windows-images-software/) image (running on Windows Server 2019)
  - Make a shallow clone, which is faster and smaller, of libde265-data with `--depth 1`
  - Use `msbuild` instead of `cmake --build`
  - Build `Release` configuration (instead of `Debug`)
  - Remove x86 job
  - Publish individual `.exe` and `.dll` artifacts
- AppVeyor: Add Arm64 build
  - Adds a Arm64 build
  - Runs the tests only on the x64 build
- AppVeyor: Allow Arm64 job to fail

The first commit is in fact the full refactor for the x64 platform. The second commit adds an run targeting the Arm64 platform, and the third commit allows the Arm64 build to fail. That last one is a separate commit so that it can be easily converted when the Arm64 build pass.

My development branch can be [viewed here](https://github.com/EwoutH/libde265/commits/patch-1/appveyor.yml) for even more granular changes.