### PR TITLE
Add framerate control to sherlock265

### DIFF
--- a/sherlock265/VideoDecoder.cc
+++ b/sherlock265/VideoDecoder.cc
@@ -132,7 +132,7 @@ void VideoDecoder::decoder_loop()
         img = de265_peek_next_picture(ctx);
         while (img==NULL)
           {
-            auto start_time = system_clock::now();
+            auto decode_start_time = system_clock::now();
 
             mutex.unlock();
             int more=1;
@@ -142,7 +142,7 @@ void VideoDecoder::decoder_loop()
             if (more && err == DE265_OK) {
               // try again to get picture
 
-              duration<double> decode_time = system_clock::now() - start_time;
+              duration<double> decode_time = system_clock::now() - decode_start_time;
               duration<double> sleep_for_time = milliseconds(1000 / mFramerate) - decode_time;
 
               if (sleep_for_time.count() > 0)

--- a/sherlock265/VideoDecoder.cc
+++ b/sherlock265/VideoDecoder.cc
@@ -37,6 +37,12 @@ using namespace videogfx;
 //#include "decctx.h"
 #include "visualize.h"
 
+#include <iostream>
+#include <ctime>
+#include <chrono>
+#include <thread>
+
+using namespace std;
 
 VideoDecoder::VideoDecoder()
   : mFH(NULL),
@@ -127,6 +133,7 @@ void VideoDecoder::decoder_loop()
         img = de265_peek_next_picture(ctx);
         while (img==NULL)
           {
+            auto start = std::chrono::system_clock::now();
             mutex.unlock();
             int more=1;
             de265_error err = de265_decode(ctx, &more);
@@ -134,6 +141,10 @@ void VideoDecoder::decoder_loop()
 
             if (more && err == DE265_OK) {
               // try again to get picture
+
+              std::chrono::duration<double> decode_time = std::chrono::system_clock::now() - start;
+              std::chrono::duration<double> sleep_for_time = std::chrono::milliseconds(33) - decode_time;
+              std::this_thread::sleep_for(sleep_for_time);
 
               img = de265_peek_next_picture(ctx);
             }

--- a/sherlock265/VideoDecoder.cc
+++ b/sherlock265/VideoDecoder.cc
@@ -148,7 +148,7 @@ void VideoDecoder::decoder_loop()
               duration<double> decode_time = system_clock::now() - start_time;
               duration<double> sleep_for_time = milliseconds(1000 / mFramerate) - decode_time;
 
-              std::this_thread::sleep_for(sleep_for_time);
+              QThread::msleep(sleep_for_time.count() * 1000);
 
               img = de265_peek_next_picture(ctx);
             }

--- a/sherlock265/VideoDecoder.cc
+++ b/sherlock265/VideoDecoder.cc
@@ -43,6 +43,7 @@ using namespace videogfx;
 #include <thread>
 
 using namespace std;
+using namespace std::chrono;
 
 VideoDecoder::VideoDecoder()
   : mFH(NULL),
@@ -133,7 +134,7 @@ void VideoDecoder::decoder_loop()
         img = de265_peek_next_picture(ctx);
         while (img==NULL)
           {
-            auto start = std::chrono::system_clock::now();
+            auto start = system_clock::now();
             mutex.unlock();
             int more=1;
             de265_error err = de265_decode(ctx, &more);
@@ -142,8 +143,9 @@ void VideoDecoder::decoder_loop()
             if (more && err == DE265_OK) {
               // try again to get picture
 
-              std::chrono::duration<double> decode_time = std::chrono::system_clock::now() - start;
-              std::chrono::duration<double> sleep_for_time = std::chrono::milliseconds(33) - decode_time;
+              duration<double> decode_time = system_clock::now() - start;
+              duration<double> sleep_for_time = milliseconds(33) - decode_time;
+
               std::this_thread::sleep_for(sleep_for_time);
 
               img = de265_peek_next_picture(ctx);

--- a/sherlock265/VideoDecoder.cc
+++ b/sherlock265/VideoDecoder.cc
@@ -37,10 +37,7 @@ using namespace videogfx;
 //#include "decctx.h"
 #include "visualize.h"
 
-#include <iostream>
-#include <ctime>
 #include <chrono>
-#include <thread>
 
 using namespace std;
 using namespace std::chrono;
@@ -353,7 +350,6 @@ void VideoDecoder::show_frame(const de265_image* img)
 
 void VideoDecoder::setFramerate(int framerate)
 {
-  std::cout << "settings framerate " << framerate << std::endl;
   mFramerate = framerate;
 }
 

--- a/sherlock265/VideoDecoder.cc
+++ b/sherlock265/VideoDecoder.cc
@@ -51,6 +51,7 @@ VideoDecoder::VideoDecoder()
     img(NULL),
     mNextBuffer(0),
     mFrameCount(0),
+    mFramerate(30),
     mPlayingVideo(false),
     mVideoEnded(false),
     mSingleStep(false),
@@ -145,7 +146,7 @@ void VideoDecoder::decoder_loop()
               // try again to get picture
 
               duration<double> decode_time = system_clock::now() - start_time;
-              duration<double> sleep_for_time = milliseconds(33) - decode_time;
+              duration<double> sleep_for_time = milliseconds(1000 / mFramerate) - decode_time;
 
               std::this_thread::sleep_for(sleep_for_time);
 
@@ -350,6 +351,10 @@ void VideoDecoder::show_frame(const de265_image* img)
   mFrameCount++;
 }
 
+void VideoDecoder::setFramerate(int framerate)
+{
+  mFramerate = framerate;
+}
 
 void VideoDecoder::showCBPartitioning(bool flag)
 {

--- a/sherlock265/VideoDecoder.cc
+++ b/sherlock265/VideoDecoder.cc
@@ -148,7 +148,7 @@ void VideoDecoder::decoder_loop()
               duration<double> decode_time = system_clock::now() - start_time;
               duration<double> sleep_for_time = milliseconds(1000 / mFramerate) - decode_time;
 
-              QThread::msleep(sleep_for_time.count() * 1000);
+              QThread::msleep(std::max(sleep_for_time.count() * 1000, (double)0));
 
               img = de265_peek_next_picture(ctx);
             }
@@ -353,6 +353,7 @@ void VideoDecoder::show_frame(const de265_image* img)
 
 void VideoDecoder::setFramerate(int framerate)
 {
+  std::cout << "settings framerate " << framerate << std::endl;
   mFramerate = framerate;
 }
 

--- a/sherlock265/VideoDecoder.cc
+++ b/sherlock265/VideoDecoder.cc
@@ -147,7 +147,7 @@ void VideoDecoder::decoder_loop()
 
               if (sleep_for_time.count() > 0)
               {
-                QThread::msleep(sleep_for_time.count() * 1000);
+                QThread::usleep(sleep_for_time.count() * 1000000);
               }
 
               img = de265_peek_next_picture(ctx);

--- a/sherlock265/VideoDecoder.cc
+++ b/sherlock265/VideoDecoder.cc
@@ -145,7 +145,10 @@ void VideoDecoder::decoder_loop()
               duration<double> decode_time = system_clock::now() - start_time;
               duration<double> sleep_for_time = milliseconds(1000 / mFramerate) - decode_time;
 
-              QThread::msleep(std::max(sleep_for_time.count() * 1000, (double)0));
+              if (sleep_for_time.count() > 0)
+              {
+                QThread::msleep(sleep_for_time.count() * 1000);
+              }
 
               img = de265_peek_next_picture(ctx);
             }

--- a/sherlock265/VideoDecoder.cc
+++ b/sherlock265/VideoDecoder.cc
@@ -134,7 +134,8 @@ void VideoDecoder::decoder_loop()
         img = de265_peek_next_picture(ctx);
         while (img==NULL)
           {
-            auto start = system_clock::now();
+            auto start_time = system_clock::now();
+
             mutex.unlock();
             int more=1;
             de265_error err = de265_decode(ctx, &more);
@@ -143,7 +144,7 @@ void VideoDecoder::decoder_loop()
             if (more && err == DE265_OK) {
               // try again to get picture
 
-              duration<double> decode_time = system_clock::now() - start;
+              duration<double> decode_time = system_clock::now() - start_time;
               duration<double> sleep_for_time = milliseconds(33) - decode_time;
 
               std::this_thread::sleep_for(sleep_for_time);

--- a/sherlock265/VideoDecoder.hh
+++ b/sherlock265/VideoDecoder.hh
@@ -64,6 +64,7 @@ public slots:
   void stopDecoder();
   void singleStepDecoder();
 
+  void setFramerate(int framerate);
   void showCBPartitioning(bool flag);
   void showTBPartitioning(bool flag);
   void showPBPartitioning(bool flag);
@@ -92,6 +93,7 @@ private:
   QImage mImgBuffers[2];
   int    mNextBuffer;
   int    mFrameCount;
+  int    mFramerate;
 
   bool   mPlayingVideo;
   bool   mVideoEnded;

--- a/sherlock265/VideoPlayer.cc
+++ b/sherlock265/VideoPlayer.cc
@@ -122,7 +122,7 @@ VideoPlayer::VideoPlayer(const char* filename)
   layout->addWidget(showPBPredModeButton,    2,4,1,1);
   layout->addWidget(showQuantPYButton,       2,5,1,1);
   layout->addWidget(showMotionVecButton,     2,6,1,1);
-  layout->addWidget(framerateSpinbox, 1, 3, 1, 1);
+  layout->addWidget(framerateSpinbox,        1,3,1,1);
   setLayout(layout);
 
 

--- a/sherlock265/VideoPlayer.cc
+++ b/sherlock265/VideoPlayer.cc
@@ -50,7 +50,7 @@ VideoPlayer::VideoPlayer(const char* filename)
 
   QSpinBox *framerateSpinbox = new QSpinBox();
   framerateSpinbox->setMinimum(1);
-  framerateSpinbox->setMaximum(60);
+  framerateSpinbox->setMaximum(300);
   framerateSpinbox->setValue(30);
   framerateSpinbox->setSuffix(" FPS");
 

--- a/sherlock265/VideoPlayer.cc
+++ b/sherlock265/VideoPlayer.cc
@@ -48,7 +48,13 @@ VideoPlayer::VideoPlayer(const char* filename)
   QObject::connect(mDecoder,    SIGNAL(displayImage(QImage*)),
                    videoWidget, SLOT(setImage(QImage*)), Qt::QueuedConnection);
 
+  QSpinBox *framerateSpinbox = new QSpinBox();
+  framerateSpinbox->setMinimum(1);
+  framerateSpinbox->setMaximum(60);
+  framerateSpinbox->setValue(30);
+  framerateSpinbox->setSuffix(" FPS");
 
+  QObject::connect(framerateSpinbox, QOverload<int>::of(&QSpinBox::valueChanged), mDecoder, &VideoDecoder::setFramerate);
 
   QPushButton* showCBPartitioningButton = new QPushButton("CB-tree");
   showCBPartitioningButton->setCheckable(true);
@@ -116,6 +122,7 @@ VideoPlayer::VideoPlayer(const char* filename)
   layout->addWidget(showPBPredModeButton,    2,4,1,1);
   layout->addWidget(showQuantPYButton,       2,5,1,1);
   layout->addWidget(showMotionVecButton,     2,6,1,1);
+  layout->addWidget(framerateSpinbox, 1, 3, 1, 1);
   setLayout(layout);
 
 


### PR DESCRIPTION
This PR adds framerate control to sherlock265.

The framerate is controlled using a Qt SpinBox element.

Default framerate is 30, which is suitable for most videos but not all.

I tried extracting the video framerate from the SPS, which is analyzed inside libde265 internals, but is not readily accessible from outside. The only option appears to be to dump the whole SPS header and process it manually, or modify libde265 to provide it with the API, which is a bit out of scope right now.

Further work:
- Detect video framerate automatically

![image](https://user-images.githubusercontent.com/1867324/146931861-4e87ce48-6073-4888-82ad-caa598e26b93.png)


