### PR TITLE
fix build error when compile with libaom

### DIFF
--- a/libde265/encoder/encoder-syntax.cc
+++ b/libde265/encoder/encoder-syntax.cc
@@ -24,7 +24,7 @@
 #include "encoder-context.h"
 #include "encoder-intrapred.h"
 #include "slice.h"
-#include "scan.h"
+#include "libde265/scan.h"
 #include "intrapred.h"
 #include "libde265/transform.h"
 #include "libde265/fallback-dct.h"

--- a/libde265/encoder/encoder-types.cc
+++ b/libde265/encoder/encoder-types.cc
@@ -23,7 +23,7 @@
 #include "encoder-types.h"
 #include "encoder-context.h"
 #include "slice.h"
-#include "scan.h"
+#include "libde265/scan.h"
 #include "intrapred.h"
 #include "libde265/transform.h"
 #include "libde265/fallback-dct.h"


### PR DESCRIPTION
when compilewith libaom,cause libaom also has a source file named "scan.h", XCode build system will use libaom/scan.h to compile libde265, which cause build error of course.
so here I indicicate which scan.h should use in libde265 to prevent this build error.