### PR TITLE
Corrected shift check.

### DIFF
--- a/libde265/cabac.cc
+++ b/libde265/cabac.cc
@@ -433,7 +433,7 @@ int  decode_CABAC_EGk_bypass(CABAC_decoder* decoder, int k)
         n++;
       }
 
-      if (n == k+MAX_PREFIX) {
+      if (n == MAX_PREFIX) {
         return 0; // TODO: error
       }
     }


### PR DESCRIPTION
This patch fixes the following commit: https://github.com/strukturag/libde265/commit/d1d39e3559fc115925107c3deb2d1ff0cba49f68. This patch was added to fix an endless loop. But the check `k+MAX_PREFIX` could still result in a value higher than` 31` and that would cause an issue with the shift on this line:

https://github.com/strukturag/libde265/blob/e587ef6e8000662b91c35ccb866c2374d3a40e27/libde265/cabac.cc#L432