### PR TITLE
Fix out of bounds memory read in derive_spatial_luma_vector_prediction

### DIFF
--- a/libde265/motion.cc
+++ b/libde265/motion.cc
@@ -1633,6 +1633,9 @@ void derive_spatial_luma_vector_prediction(base_context* ctx,
   int refIdxA=-1;
 
   // the POC we want to reference in this PB
+  if (refIdxLX >= MAX_NUM_REF_PICS) {
+    return;
+  }
   const de265_image* tmpimg = ctx->get_image(shdr->RefPicList[X][ refIdxLX ]);
   if (tmpimg==NULL) { return; }
   const int referenced_POC = tmpimg->PicOrderCntVal;


### PR DESCRIPTION
This PR fixes out of bounds memory read in derive_spatial_luma_vector_prediction revealed by fuzzing kimageformats:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=40107

When `refIdxLX` is larger than `MAX_NUM_REF_PICS` in `shdr->RefPicList[X][ refIdxLX ]` it leads to out of bounds memory read.
The `refIdxLX` is assigned much higher in the call stack, but the first usage is only in the function. I have added return statement similarly to a memory allocation failure handling in the same function.