### PR TITLE
Fix out of bounds memory read in apply_sao_internal

### DIFF
--- a/libde265/sao.cc
+++ b/libde265/sao.cc
@@ -217,10 +217,14 @@ void apply_sao_internal(de265_image* img, int xCtb,int yCtb,
           if (bandShift >= 8) {
             bandIdx = 0;
           } else {
-            bandIdx = bandTable[ in_img[xC+i+(yC+j)*in_stride]>>bandShift ];
+            int bandTableIdx = in_img[xC+i+(yC+j)*in_stride]>>bandShift;
+            if (bandTableIdx >= sizeof(bandTable)/sizeof(bandTable[0]))
+              bandIdx = 0;
+            else
+              bandIdx = bandTable[ bandTableIdx ];
           }
 
-          if (bandIdx>0) {
+          if (bandIdx>0 && bandIdx <= 4) {
             int offset = saoinfo->saoOffsetVal[cIdx][bandIdx-1];
 
             logtrace(LogSAO,"%d %d (%d) offset %d  %x -> %x\n",xC+i,yC+j,bandIdx,


### PR DESCRIPTION
This PR fixes out of bounds memory read in apply_sao_internal revealed by fuzzing kimageformats:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=31485

There are two issues:
1. `saoOffsetVal` is defined as `int8_t  saoOffsetVal[3][4];`. When `bandIdx` is larger than `4` it leads to out of bounds memory read.
2. `bandTable` is defined as `int bandTable[32]`. When `in_img[xC+i+(yC+j)*in_stride]>>bandShift` results in > 31 it leads to out of bounds memory read.