### PR TITLE
make: Include m4 files in release tarball.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,10 @@ endif
 EXTRA_DIST = \
   autogen.sh \
   build.bat \
+  m4/ax_compare_version.m4 \
+  m4/ax_cxx_compile_stdcxx_11.m4 \
   m4/m4_ax_check_compile_flag.m4 \
+  m4/visibility.m4 \
   Makefile.vc7 \
   CMakeLists.txt \
   README.md \


### PR DESCRIPTION
The file is not automatically included because the call to `gl_VISIBILITY` is commented in
https://github.com/strukturag/libde265/blob/2b5dedd1a238267a59de0baaa91035f01194ce23/configure.ac#L59

However in packaging the call is patched back in to not expose all symbols but then the macro is not defined as the file is missing. Better to explicitly include the file to make sure it's available.