### PR TITLE
Try to mitigate asan failures.

### DIFF
--- a/libde265/motion.cc
+++ b/libde265/motion.cc
@@ -348,6 +348,16 @@ void generate_inter_prediction_samples(base_context* ctx,
 
       logtrace(LogMotion, "refIdx: %d -> dpb[%d]\n", vi->refIdx[l], shdr->RefPicList[l][vi->refIdx[l]]);
 
+      if (refPic) {
+          auto nonconst_refPic = const_cast<de265_image*>(refPic); /* shared_ptr.get() chokes on const.*/
+          auto refsps = nonconst_refPic->get_shared_sps().get();
+          auto imgsps = img->get_shared_sps().get();
+          if(refsps != imgsps) {
+              // rejecting reference image created with different sps.
+              refPic = nullptr;
+          }
+      }
+
       if (!refPic || refPic->PicState == UnusedForReference) {
         img->integrity = INTEGRITY_DECODING_ERRORS;
         ctx->add_warning(DE265_WARNING_NONEXISTING_REFERENCE_PICTURE_ACCESSED, false);


### PR DESCRIPTION
See #345 for my analysis and details…

(This PR is just for discussion.)

(The CVE references are obtained from the Debian security tracker, which links the issues.)

This makes the following POCs stop failing:

- poc3 (#337)
- poc7-1 (#341) CVE-2022-43239 (note: does NOT fix poc7-2)
- poc8-2, poc8-3, poc8-4 (#342) CVE-2022-43244   (note: does NOT fix poc8-1)
- poc11-1, poc11-2 (#345) CVE-2022-43249
- poc12 (#346)
- poc13 (#347) CVE-2022-43252
- poc16 (#350)