### PR TITLE
Include libde265 pkgconfig when using cmake on unix

### DIFF
--- a/libde265/CMakeLists.txt
+++ b/libde265/CMakeLists.txt
@@ -126,5 +126,7 @@ install(EXPORT libde265Config DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libde26
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libde265ConfigVersion.cmake DESTINATION
     "${CMAKE_INSTALL_LIBDIR}/cmake/libde265")
 
-configure_file(../libde265.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libde265.pc @ONLY)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libde265.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+if(UNIX)
+  configure_file(../libde265.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libde265.pc @ONLY)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libde265.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+endif()

--- a/libde265/CMakeLists.txt
+++ b/libde265/CMakeLists.txt
@@ -125,3 +125,6 @@ install(EXPORT libde265Config DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/libde26
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libde265ConfigVersion.cmake DESTINATION
     "${CMAKE_INSTALL_LIBDIR}/cmake/libde265")
+
+configure_file(../libde265.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libde265.pc @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libde265.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)


### PR DESCRIPTION
I'm trying to package this (and libheif) on conda-forge but it seems the pkgconfig is missing when building with cmake.

There is another pull request https://github.com/strukturag/libde265/pull/333 that does this, however the other changes in that pull request are not necessary.

Thank you for your work on libde265 and libheif! 