### PR TITLE
Fix Windows DLL name

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ build_script:
 before_test:
   - copy /y build\dec265\%CONFIGURATION%\dec265.exe build
   - copy /y build\enc265\%CONFIGURATION%\enc265.exe build
-  - copy /y build\libde265\%CONFIGURATION%\de265.dll build
+  - copy /y build\libde265\%CONFIGURATION%\libde265.dll build
 
 test_script:
   - build\dec265.exe -q -c -f 100 libde265-data\IDR-only\paris-352x288-intra.bin

--- a/libde265/CMakeLists.txt
+++ b/libde265/CMakeLists.txt
@@ -113,13 +113,13 @@ if(NOT DISABLE_SSE)
   endif()
 endif()
 
-add_library(libde265 ${libde265_sources} ${ENCODER_OBJECTS} ${X86_OBJECTS})
-target_link_libraries(libde265 PRIVATE Threads::Threads)
-target_include_directories(libde265 PRIVATE ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+add_library(de265 ${libde265_sources} ${ENCODER_OBJECTS} ${X86_OBJECTS})
+target_link_libraries(de265 PRIVATE Threads::Threads)
+target_include_directories(de265 PRIVATE ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 
 write_basic_package_version_file(libde265ConfigVersion.cmake COMPATIBILITY ExactVersion)
 
-install(TARGETS libde265 EXPORT libde265Config
+install(TARGETS de265 EXPORT libde265Config
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/libde265/CMakeLists.txt
+++ b/libde265/CMakeLists.txt
@@ -113,13 +113,13 @@ if(NOT DISABLE_SSE)
   endif()
 endif()
 
-add_library(de265 ${libde265_sources} ${ENCODER_OBJECTS} ${X86_OBJECTS})
-target_link_libraries(de265 PRIVATE Threads::Threads)
-target_include_directories(de265 PRIVATE ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+add_library(libde265 ${libde265_sources} ${ENCODER_OBJECTS} ${X86_OBJECTS})
+target_link_libraries(libde265 PRIVATE Threads::Threads)
+target_include_directories(libde265 PRIVATE ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 
 write_basic_package_version_file(libde265ConfigVersion.cmake COMPATIBILITY ExactVersion)
 
-install(TARGETS de265 EXPORT libde265Config
+install(TARGETS libde265 EXPORT libde265Config
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/libde265/CMakeLists.txt
+++ b/libde265/CMakeLists.txt
@@ -119,6 +119,10 @@ target_include_directories(de265 PRIVATE ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_BIN
 
 write_basic_package_version_file(libde265ConfigVersion.cmake COMPATIBILITY ExactVersion)
 
+if (WIN32)
+    set_target_properties(de265 PROPERTIES PREFIX "lib")
+endif()
+
 install(TARGETS de265 EXPORT libde265Config
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
A recent cleanup has accidentally changed the Windows DLL name to `de265.dll`.
Even though this seems to be the better choice for Windows (we also use `heif.dll` for libheif), we change this back to stay compatible with the old version.