### PR TITLE
Use int16 min/max for _mm_set_epi16() calls

### DIFF
--- a/libde265/x86/sse-motion.cc
+++ b/libde265/x86/sse-motion.cc
@@ -3527,9 +3527,9 @@ void ff_hevc_put_hevc_qpel_h_1_v_1_sse(int16_t *dst, ptrdiff_t dststride,
             r0 = _mm_srli_epi32(r0, 6);
 
             r1 = _mm_and_si128(r1,
-                    _mm_set_epi16(0, 65535, 0, 65535, 0, 65535, 0, 65535));
+                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
             r0 = _mm_and_si128(r0,
-                    _mm_set_epi16(0, 65535, 0, 65535, 0, 65535, 0, 65535));
+                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
             r0 = _mm_hadd_epi16(r0, r1);
             _mm_store_si128((__m128i *) &dst[x], r0);
 
@@ -3710,9 +3710,9 @@ void ff_hevc_put_hevc_qpel_h_1_v_2_sse(int16_t *dst, ptrdiff_t dststride,
             r0 = _mm_srli_epi32(r0, 6);
 
             r1 = _mm_and_si128(r1,
-                    _mm_set_epi16(0, 65535, 0, 65535, 0, 65535, 0, 65535));
+                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
             r0 = _mm_and_si128(r0,
-                    _mm_set_epi16(0, 65535, 0, 65535, 0, 65535, 0, 65535));
+                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
             r0 = _mm_hadd_epi16(r0, r1);
             _mm_store_si128((__m128i *) &dst[x], r0);
 
@@ -3887,9 +3887,9 @@ void ff_hevc_put_hevc_qpel_h_1_v_3_sse(int16_t *dst, ptrdiff_t dststride,
             r0 = _mm_srli_epi32(r0, 6);
 
             r1 = _mm_and_si128(r1,
-                    _mm_set_epi16(0, 65535, 0, 65535, 0, 65535, 0, 65535));
+                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
             r0 = _mm_and_si128(r0,
-                    _mm_set_epi16(0, 65535, 0, 65535, 0, 65535, 0, 65535));
+                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
             r0 = _mm_hadd_epi16(r0, r1);
             _mm_store_si128((__m128i *) &dst[x], r0);
 
@@ -4058,9 +4058,9 @@ void ff_hevc_put_hevc_qpel_h_2_v_1_sse(int16_t *dst, ptrdiff_t dststride,
             r0 = _mm_srli_epi32(r0, 6);
 
             r1 = _mm_and_si128(r1,
-                    _mm_set_epi16(0, 65535, 0, 65535, 0, 65535, 0, 65535));
+                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
             r0 = _mm_and_si128(r0,
-                    _mm_set_epi16(0, 65535, 0, 65535, 0, 65535, 0, 65535));
+                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
             r0 = _mm_hadd_epi16(r0, r1);
             _mm_store_si128((__m128i *) &dst[x], r0);
 
@@ -4241,9 +4241,9 @@ void ff_hevc_put_hevc_qpel_h_2_v_2_sse(int16_t *dst, ptrdiff_t dststride,
             r0 = _mm_srli_epi32(r0, 6);
 
             r1 = _mm_and_si128(r1,
-                    _mm_set_epi16(0, 65535, 0, 65535, 0, 65535, 0, 65535));
+                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
             r0 = _mm_and_si128(r0,
-                    _mm_set_epi16(0, 65535, 0, 65535, 0, 65535, 0, 65535));
+                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
             r0 = _mm_hadd_epi16(r0, r1);
             _mm_store_si128((__m128i *) &dst[x], r0);
 
@@ -4419,9 +4419,9 @@ void ff_hevc_put_hevc_qpel_h_2_v_3_sse(int16_t *dst, ptrdiff_t dststride,
             r0 = _mm_srli_epi32(r0, 6);
 
             r1 = _mm_and_si128(r1,
-                    _mm_set_epi16(0, 65535, 0, 65535, 0, 65535, 0, 65535));
+                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
             r0 = _mm_and_si128(r0,
-                    _mm_set_epi16(0, 65535, 0, 65535, 0, 65535, 0, 65535));
+                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
             r0 = _mm_hadd_epi16(r0, r1);
             _mm_store_si128((__m128i *) &dst[x], r0);
 
@@ -4592,9 +4592,9 @@ void ff_hevc_put_hevc_qpel_h_3_v_1_sse(int16_t *dst, ptrdiff_t dststride,
             r0 = _mm_srli_epi32(r0, 6);
 
             r1 = _mm_and_si128(r1,
-                    _mm_set_epi16(0, 65535, 0, 65535, 0, 65535, 0, 65535));
+                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
             r0 = _mm_and_si128(r0,
-                    _mm_set_epi16(0, 65535, 0, 65535, 0, 65535, 0, 65535));
+                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
             r0 = _mm_hadd_epi16(r0, r1);
             _mm_store_si128((__m128i *) &dst[x], r0);
 
@@ -4778,9 +4778,9 @@ void ff_hevc_put_hevc_qpel_h_3_v_2_sse(int16_t *dst, ptrdiff_t dststride,
             r0 = _mm_srli_epi32(r0, 6);
 
             r1 = _mm_and_si128(r1,
-                    _mm_set_epi16(0, 65535, 0, 65535, 0, 65535, 0, 65535));
+                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
             r0 = _mm_and_si128(r0,
-                    _mm_set_epi16(0, 65535, 0, 65535, 0, 65535, 0, 65535));
+                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
             r0 = _mm_hadd_epi16(r0, r1);
             _mm_store_si128((__m128i *) &dst[x], r0);
 
@@ -4958,9 +4958,9 @@ void ff_hevc_put_hevc_qpel_h_3_v_3_sse(int16_t *dst, ptrdiff_t dststride,
             r0 = _mm_srli_epi32(r0, 6);
 
             r1 = _mm_and_si128(r1,
-                    _mm_set_epi16(0, 65535, 0, 65535, 0, 65535, 0, 65535));
+                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
             r0 = _mm_and_si128(r0,
-                    _mm_set_epi16(0, 65535, 0, 65535, 0, 65535, 0, 65535));
+                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
             r0 = _mm_hadd_epi16(r0, r1);
             _mm_store_si128((__m128i *) &dst[x], r0);
 

--- a/libde265/x86/sse-motion.cc
+++ b/libde265/x86/sse-motion.cc
@@ -3527,9 +3527,9 @@ void ff_hevc_put_hevc_qpel_h_1_v_1_sse(int16_t *dst, ptrdiff_t dststride,
             r0 = _mm_srli_epi32(r0, 6);
 
             r1 = _mm_and_si128(r1,
-                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
+                    _mm_set_epi16(0, -1, 0, -1, 0, -1, 0, -1));
             r0 = _mm_and_si128(r0,
-                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
+                    _mm_set_epi16(0, -1, 0, -1, 0, -1, 0, -1));
             r0 = _mm_hadd_epi16(r0, r1);
             _mm_store_si128((__m128i *) &dst[x], r0);
 
@@ -3710,9 +3710,9 @@ void ff_hevc_put_hevc_qpel_h_1_v_2_sse(int16_t *dst, ptrdiff_t dststride,
             r0 = _mm_srli_epi32(r0, 6);
 
             r1 = _mm_and_si128(r1,
-                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
+                    _mm_set_epi16(0, -1, 0, -1, 0, -1, 0, -1));
             r0 = _mm_and_si128(r0,
-                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
+                    _mm_set_epi16(0, -1, 0, -1, 0, -1, 0, -1));
             r0 = _mm_hadd_epi16(r0, r1);
             _mm_store_si128((__m128i *) &dst[x], r0);
 
@@ -3887,9 +3887,9 @@ void ff_hevc_put_hevc_qpel_h_1_v_3_sse(int16_t *dst, ptrdiff_t dststride,
             r0 = _mm_srli_epi32(r0, 6);
 
             r1 = _mm_and_si128(r1,
-                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
+                    _mm_set_epi16(0, -1, 0, -1, 0, -1, 0, -1));
             r0 = _mm_and_si128(r0,
-                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
+                    _mm_set_epi16(0, -1, 0, -1, 0, -1, 0, -1));
             r0 = _mm_hadd_epi16(r0, r1);
             _mm_store_si128((__m128i *) &dst[x], r0);
 
@@ -4058,9 +4058,9 @@ void ff_hevc_put_hevc_qpel_h_2_v_1_sse(int16_t *dst, ptrdiff_t dststride,
             r0 = _mm_srli_epi32(r0, 6);
 
             r1 = _mm_and_si128(r1,
-                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
+                    _mm_set_epi16(0, -1, 0, -1, 0, -1, 0, -1));
             r0 = _mm_and_si128(r0,
-                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
+                    _mm_set_epi16(0, -1, 0, -1, 0, -1, 0, -1));
             r0 = _mm_hadd_epi16(r0, r1);
             _mm_store_si128((__m128i *) &dst[x], r0);
 
@@ -4241,9 +4241,9 @@ void ff_hevc_put_hevc_qpel_h_2_v_2_sse(int16_t *dst, ptrdiff_t dststride,
             r0 = _mm_srli_epi32(r0, 6);
 
             r1 = _mm_and_si128(r1,
-                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
+                    _mm_set_epi16(0, -1, 0, -1, 0, -1, 0, -1));
             r0 = _mm_and_si128(r0,
-                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
+                    _mm_set_epi16(0, -1, 0, -1, 0, -1, 0, -1));
             r0 = _mm_hadd_epi16(r0, r1);
             _mm_store_si128((__m128i *) &dst[x], r0);
 
@@ -4419,9 +4419,9 @@ void ff_hevc_put_hevc_qpel_h_2_v_3_sse(int16_t *dst, ptrdiff_t dststride,
             r0 = _mm_srli_epi32(r0, 6);
 
             r1 = _mm_and_si128(r1,
-                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
+                    _mm_set_epi16(0, -1, 0, -1, 0, -1, 0, -1));
             r0 = _mm_and_si128(r0,
-                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
+                    _mm_set_epi16(0, -1, 0, -1, 0, -1, 0, -1));
             r0 = _mm_hadd_epi16(r0, r1);
             _mm_store_si128((__m128i *) &dst[x], r0);
 
@@ -4592,9 +4592,9 @@ void ff_hevc_put_hevc_qpel_h_3_v_1_sse(int16_t *dst, ptrdiff_t dststride,
             r0 = _mm_srli_epi32(r0, 6);
 
             r1 = _mm_and_si128(r1,
-                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
+                    _mm_set_epi16(0, -1, 0, -1, 0, -1, 0, -1));
             r0 = _mm_and_si128(r0,
-                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
+                    _mm_set_epi16(0, -1, 0, -1, 0, -1, 0, -1));
             r0 = _mm_hadd_epi16(r0, r1);
             _mm_store_si128((__m128i *) &dst[x], r0);
 
@@ -4778,9 +4778,9 @@ void ff_hevc_put_hevc_qpel_h_3_v_2_sse(int16_t *dst, ptrdiff_t dststride,
             r0 = _mm_srli_epi32(r0, 6);
 
             r1 = _mm_and_si128(r1,
-                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
+                    _mm_set_epi16(0, -1, 0, -1, 0, -1, 0, -1));
             r0 = _mm_and_si128(r0,
-                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
+                    _mm_set_epi16(0, -1, 0, -1, 0, -1, 0, -1));
             r0 = _mm_hadd_epi16(r0, r1);
             _mm_store_si128((__m128i *) &dst[x], r0);
 
@@ -4958,9 +4958,9 @@ void ff_hevc_put_hevc_qpel_h_3_v_3_sse(int16_t *dst, ptrdiff_t dststride,
             r0 = _mm_srli_epi32(r0, 6);
 
             r1 = _mm_and_si128(r1,
-                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
+                    _mm_set_epi16(0, -1, 0, -1, 0, -1, 0, -1));
             r0 = _mm_and_si128(r0,
-                    _mm_set_epi16(-32766, 32767, -32766, 32767, -32766, 32767, -32766, 32767));
+                    _mm_set_epi16(0, -1, 0, -1, 0, -1, 0, -1));
             r0 = _mm_hadd_epi16(r0, r1);
             _mm_store_si128((__m128i *) &dst[x], r0);
 


### PR DESCRIPTION
This fixes a bug that causes g0 overflows when compiled on Intel processors and run on AMD Ryzen processors.

According to Intel, the `_mm_set_epi16()` function takes signed shorts (int16): https://www.intel.com/content/www/us/en/docs/intrinsics-guide/index.html#text=mm_set_epi16&ig_expand=6355,6355

But 0-65535 is the range of uint16, not int16; causing an overflow to -1. This is warned of by the compiler: `implict conversion from int to short changes value from 65535 to -1`

For whatever reason, compiling and running on AMD Ryzen chip succeeded fine. Compiling and runing on an Intel chip also worked fine. But compiling on Intel and running on AMD caused an exception.

Using the int16 range fixes the problem. However, this is not my skill set and I am not sure if this is the right fix. Please verify. Thank you!