### PR TITLE
Possibly fix stack-based buffer overflow

### DIFF
--- a/libde265/refpic.cc
+++ b/libde265/refpic.cc
@@ -416,7 +416,7 @@ void dump_compact_short_term_ref_pic_set(const ref_pic_set* set, int range, FILE
 
   for (int i=set->NumNegativePics-1;i>=0;i--) {
     int n = set->DeltaPocS0[i];
-    if (n>=-range) {
+    if (n>=-range && n<=range) {
       if (set->UsedByCurrPicS0[i]) log[n+range] = 'X';
       else log[n+range] = 'o';
     } else { log2fh(fh,"*%d%c ",n, set->UsedByCurrPicS0[i] ? 'X':'o'); }
@@ -424,7 +424,7 @@ void dump_compact_short_term_ref_pic_set(const ref_pic_set* set, int range, FILE
 
   for (int i=set->NumPositivePics-1;i>=0;i--) {
     int n = set->DeltaPocS1[i];
-    if (n<=range) {
+    if (n>=-range && n<=range) {
       if (set->UsedByCurrPicS1[i]) log[n+range] = 'X';
       else log[n+range] = 'o';
     } else { log2fh(fh,"*%d%c ",n, set->UsedByCurrPicS1[i] ? 'X':'o'); }


### PR DESCRIPTION
Added more strict checks for array indexes in libde265/refpic.cc. It possibly fixes #399, #400 and #401