### PR TITLE
Update libde265.pc.in

### DIFF
--- a/libde265.pc.in
+++ b/libde265.pc.in
@@ -6,7 +6,7 @@ includedir=@includedir@
 Name: libde265
 Description: H.265/HEVC video decoder.
 URL: https://github.com/strukturag/libde265
-Version: @VERSION@
+Version: @PROJECT_VERSION@
 Requires: 
 Libs: -lde265 -L${libdir}
 Libs.private: @LIBS@ -lstdc++


### PR DESCRIPTION
Current libde265.pc.in file use `@VERSION@` will cause the value of version is null in pc file:
```
prefix=${pcfiledir}/../..
exec_prefix=${prefix}
libdir=${exec_prefix}/lib
includedir=${prefix}/../include

Name: libde265
Description: H.265/HEVC video decoder.
URL: https://github.com/strukturag/libde265
Version: 

Libs: -lde265 "-L${libdir}" -lstdc++
Requires: 
Cflags: "-I${includedir}"
```
Use `@PROJECT_VERSION@` will fix this issue.