### PR TITLE
dec265: Migrate to SDL 2.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ include(CheckFunctionExists)
 option(ENABLE_SDL "Enable SDL" ON)
 
 if (ENABLE_SDL)
-	find_package(SDL)
+	find_package(SDL2)
 endif()
 
 find_package(Threads REQUIRED)

--- a/configure.ac
+++ b/configure.ac
@@ -308,8 +308,8 @@ if eval "test x$enable_dec265 = xyes" || eval "test x$enable_sherlock265 = xyes"
 fi
 
 if eval "test x$enable_dec265 = xyes" ; then
-   PKG_CHECK_MODULES([SDL], [sdl],
-                     [AC_DEFINE([HAVE_SDL], [1], [Whether libsdl was found.])
+   PKG_CHECK_MODULES([SDL], [sdl2],
+                     [AC_DEFINE([HAVE_SDL], [1], [Whether libsdl2 was found.])
                       AC_SUBST(SDL_CFLAGS)
                       AC_SUBST(SDL_LIBS)
                       have_sdl="yes"],
@@ -332,7 +332,7 @@ AM_CONDITIONAL([HAVE_SWSCALE], [test "x$have_swscale" = "xyes"])
 AM_CONDITIONAL([HAVE_SDL], [test "x$have_sdl" = "xyes"])
 
 if eval "test $enable_dec265 = yes" && eval "test $have_videogfx != yes" && eval "test $have_sdl != yes" ; then
-  AC_MSG_WARN([Did not find libvideogfx or libsdl, video output of dec265 will be disabled.])
+  AC_MSG_WARN([Did not find libvideogfx or libsdl2, video output of dec265 will be disabled.])
 fi
 
 if eval "test $enable_sherlock265 = yes" && eval "test $have_videogfx != yes" && eval "test $have_swscale != yes" ; then

--- a/dec265/CMakeLists.txt
+++ b/dec265/CMakeLists.txt
@@ -2,15 +2,15 @@ add_executable (dec265 dec265.cc)
 
 target_link_libraries (dec265 PRIVATE de265)
 
-if(SDL_FOUND)
+if(SDL2_FOUND)
   target_sources(dec265 PRIVATE sdl.cc)
   target_compile_definitions(dec265 PRIVATE HAVE_SDL)
-  target_include_directories (dec265 PRIVATE "${SDL_INCLUDE_DIR}")
-  target_link_libraries (dec265 PRIVATE ${SDL_LIBRARY})
+  target_include_directories (dec265 PRIVATE "${SDL2_INCLUDE_DIRS}")
+  target_link_libraries (dec265 PRIVATE ${SDL2_LIBRARIES})
 endif()
 
 if(MSVC)
-  target_sources(dec265 PRIVATE 
+  target_sources(dec265 PRIVATE
     ../extra/getopt.c
     ../extra/getopt_long.c
   )

--- a/dec265/sdl.hh
+++ b/dec265/sdl.hh
@@ -48,10 +48,13 @@ public:
   bool isOpen() const { return mWindowOpen; }
 
 private:
-  SDL_Surface *mScreen;
-  SDL_Overlay *mYUVOverlay;
+  SDL_Window *mWindow = nullptr;
+  SDL_Renderer *mRenderer = nullptr;
+  SDL_Texture *mTexture = nullptr;
   SDL_Rect     rect;
   bool         mWindowOpen;
+  uint8_t *mPixels = nullptr;
+  int mStride = 0;
 
   SDL_Chroma mChroma;
 

--- a/scripts/ci-before-install-linux.sh
+++ b/scripts/ci-before-install-linux.sh
@@ -29,7 +29,7 @@ while true; do echo "Still alive at $(date) ..."; sleep 60; kill -0 "$$" || exit
 if [ -z "$TARGET_HOST" ]; then
     INSTALL_PACKAGES="$INSTALL_PACKAGES \
         valgrind \
-        libsdl-dev \
+        libsdl2-dev \
         qt5-default \
         libswscale-dev \
         "


### PR DESCRIPTION
SDL 1.2 is deprecated and will be removed from distributions, so migrate to SDL 2.

Fixes #412 

@farindk rendering is only tested with `display420` as I didn't have streams for `display400`, `display422`, `display444as422` and `display444as420`.