### PR TITLE
Resolve some of the -Wsign-compare warnings

### DIFF
--- a/libde265/configparam.cc
+++ b/libde265/configparam.cc
@@ -236,7 +236,7 @@ bool config_parameters::parse_command_line_params(int* argc, char** argv, int* f
 
         bool option_found=false;
 
-        for (int o=0;o<mOptions.size();o++) {
+        for (size_t o=0;o<mOptions.size();o++) {
           if (mOptions[o]->hasLongOption() && strcmp(mOptions[o]->getLongOption().c_str(),
                                                      argv[i]+2)==0) {
             option_found=true;
@@ -271,7 +271,7 @@ bool config_parameters::parse_command_line_params(int* argc, char** argv, int* f
 
           bool option_found=false;
 
-          for (int o=0;o<mOptions.size();o++) {
+          for (size_t o=0;o<mOptions.size();o++) {
             if (mOptions[o]->getShortOption() == option) {
               option_found=true;
 
@@ -318,7 +318,7 @@ bool config_parameters::parse_command_line_params(int* argc, char** argv, int* f
 
 void config_parameters::print_params() const
 {
-  for (int i=0;i<mOptions.size();i++) {
+  for (size_t i=0;i<mOptions.size();i++) {
     const option_base* o = mOptions[i];
 
     std::stringstream sstr;

--- a/libde265/decctx.cc
+++ b/libde265/decctx.cc
@@ -186,11 +186,11 @@ image_unit::image_unit()
 
 image_unit::~image_unit()
 {
-  for (int i=0;i<slice_units.size();i++) {
+  for (size_t i=0;i<slice_units.size();i++) {
     delete slice_units[i];
   }
 
-  for (int i=0;i<tasks.size();i++) {
+  for (size_t i=0;i<tasks.size();i++) {
     delete tasks[i];
   }
 }
@@ -704,7 +704,7 @@ de265_error decoder_context::read_slice_NAL(bitreader& reader, NAL_unit* nal, na
 
 template <class T> void pop_front(std::vector<T>& vec)
 {
-  for (int i=1;i<vec.size();i++)
+  for (size_t i=1;i<vec.size();i++)
     vec[i-1] = vec[i];
 
   vec.pop_back();
@@ -781,7 +781,7 @@ de265_error decoder_context::decode_some(bool* did_work)
 
     // process suffix SEIs
 
-    for (int i=0;i<imgunit->suffix_SEIs.size();i++) {
+    for (size_t i=0;i<imgunit->suffix_SEIs.size();i++) {
       const sei_message& sei = imgunit->suffix_SEIs[i];
 
       err = process_sei(&sei, imgunit->img);
@@ -1094,7 +1094,7 @@ de265_error decoder_context::decode_slice_unit_WPP(image_unit* imgunit,
 
   img->wait_for_completion();
 
-  for (int i=0;i<imgunit->tasks.size();i++)
+  for (size_t i=0;i<imgunit->tasks.size();i++)
     delete imgunit->tasks[i];
   imgunit->tasks.clear();
 
@@ -1184,7 +1184,7 @@ de265_error decoder_context::decode_slice_unit_tiles(image_unit* imgunit,
 
   img->wait_for_completion();
 
-  for (int i=0;i<imgunit->tasks.size();i++)
+  for (size_t i=0;i<imgunit->tasks.size();i++)
     delete imgunit->tasks[i];
   imgunit->tasks.clear();
 
@@ -1475,7 +1475,7 @@ de265_error decoder_context::process_reference_picture_set(slice_segment_header*
        lower POCs seems to be compliant to the reference decoder.
     */
 
-    for (int i=0;i<dpb.size();i++) {
+    for (size_t i=0;i<dpb.size();i++) {
       de265_image* img = dpb.get_image(i);
 
       if (img->PicState != UnusedForReference &&
@@ -2145,7 +2145,7 @@ bool decoder_context::process_slice_segment_header(slice_segment_header* hdr,
 
 void decoder_context::remove_images_from_dpb(const std::vector<int>& removeImageList)
 {
-  for (int i=0;i<removeImageList.size();i++) {
+  for (size_t i=0;i<removeImageList.size();i++) {
     int idx = dpb.DPB_index_of_picture_with_ID( removeImageList[i] );
     if (idx>=0) {
       //printf("remove ID %d\n", removeImageList[i]);

--- a/libde265/decctx.h
+++ b/libde265/decctx.h
@@ -203,7 +203,7 @@ public:
   std::vector<sei_message> suffix_SEIs;
 
   slice_unit* get_next_unprocessed_slice_segment() const {
-    for (int i=0;i<slice_units.size();i++) {
+    for (size_t i=0;i<slice_units.size();i++) {
       if (slice_units[i]->state == slice_unit::Unprocessed) {
         return slice_units[i];
       }
@@ -213,7 +213,7 @@ public:
   }
 
   slice_unit* get_prev_slice_segment(slice_unit* s) const {
-    for (int i=1; i<slice_units.size(); i++) {
+    for (size_t i=1; i<slice_units.size(); i++) {
       if (slice_units[i]==s) {
         return slice_units[i-1];
       }
@@ -223,7 +223,7 @@ public:
   }
 
   slice_unit* get_next_slice_segment(slice_unit* s) const {
-    for (int i=0; i<slice_units.size()-1; i++) {
+    for (size_t i=0; i<slice_units.size()-1; i++) {
       if (slice_units[i]==s) {
         return slice_units[i+1];
       }
@@ -233,8 +233,8 @@ public:
   }
 
   void dump_slices() const {
-    for (int i=0; i<slice_units.size(); i++) {
-      printf("[%d] = %p\n",i,slice_units[i]);
+    for (size_t i=0; i<slice_units.size(); i++) {
+      printf("[%zu] = %p\n",i,slice_units[i]);
     }
   }
 

--- a/libde265/dpb.cc
+++ b/libde265/dpb.cc
@@ -36,14 +36,14 @@ decoded_picture_buffer::decoded_picture_buffer()
 
 decoded_picture_buffer::~decoded_picture_buffer()
 {
-  for (int i=0;i<dpb.size();i++)
+  for (size_t i=0;i<dpb.size();i++)
     delete dpb[i];
 }
 
 
 void decoded_picture_buffer::log_dpb_content() const
 {
-  for (int i=0;i<dpb.size();i++) {
+  for (size_t i=0;i<dpb.size();i++) {
     loginfo(LogHighlevel, " DPB %d: POC=%d, ID=%d %s %s\n", i,
             dpb[i]->PicOrderCntVal,
             dpb[i]->get_ID(),
@@ -63,7 +63,7 @@ bool decoded_picture_buffer::has_free_dpb_picture(bool high_priority) const
   if (dpb.size() < max_images_in_DPB) return true;
 
   // scan for empty slots
-  for (int i=0;i<dpb.size();i++) {
+  for (size_t i=0;i<dpb.size();i++) {
     if (dpb[i]->PicOutputFlag==false && dpb[i]->PicState == UnusedForReference) {
       return true;
     }
@@ -81,7 +81,7 @@ int decoded_picture_buffer::DPB_index_of_picture_with_POC(int poc, int currentID
   //loginfo(LogDPB,"searching for short-term reference POC=%d\n",poc);
 
   if (preferLongTerm) {
-    for (int k=0;k<dpb.size();k++) {
+    for (size_t k=0;k<dpb.size();k++) {
       if (dpb[k]->PicOrderCntVal == poc &&
           dpb[k]->removed_at_picture_id > currentID &&
           dpb[k]->PicState == UsedForLongTermReference) {
@@ -90,7 +90,7 @@ int decoded_picture_buffer::DPB_index_of_picture_with_POC(int poc, int currentID
     }
   }
 
-  for (int k=0;k<dpb.size();k++) {
+  for (size_t k=0;k<dpb.size();k++) {
     if (dpb[k]->PicOrderCntVal == poc &&
         dpb[k]->removed_at_picture_id > currentID &&
         dpb[k]->PicState != UnusedForReference) {
@@ -107,7 +107,7 @@ int decoded_picture_buffer::DPB_index_of_picture_with_LSB(int lsb, int currentID
   logdebug(LogHeaders,"get access to picture with LSB %d from DPB\n",lsb);
 
   if (preferLongTerm) {
-    for (int k=0;k<dpb.size();k++) {
+    for (size_t k=0;k<dpb.size();k++) {
       if (dpb[k]->picture_order_cnt_lsb == lsb &&
           dpb[k]->removed_at_picture_id > currentID &&
           dpb[k]->PicState == UsedForLongTermReference) {
@@ -116,7 +116,7 @@ int decoded_picture_buffer::DPB_index_of_picture_with_LSB(int lsb, int currentID
     }
   }
 
-  for (int k=0;k<dpb.size();k++) {
+  for (size_t k=0;k<dpb.size();k++) {
     if (dpb[k]->picture_order_cnt_lsb == lsb &&
         dpb[k]->removed_at_picture_id > currentID &&
         dpb[k]->PicState != UnusedForReference) {
@@ -132,7 +132,7 @@ int decoded_picture_buffer::DPB_index_of_picture_with_ID(int id) const
 {
   logdebug(LogHeaders,"get access to picture with ID %d from DPB\n",id);
 
-  for (int k=0;k<dpb.size();k++) {
+  for (size_t k=0;k<dpb.size();k++) {
     if (dpb[k]->get_ID() == id) {
       return k;
     }
@@ -150,7 +150,7 @@ void decoded_picture_buffer::output_next_picture_in_reorder_buffer()
 
   int minPOC = reorder_output_queue[0]->PicOrderCntVal;
   int minIdx = 0;
-  for (int i=1;i<reorder_output_queue.size();i++)
+  for (size_t i=1;i<reorder_output_queue.size();i++)
     {
       if (reorder_output_queue[i]->PicOrderCntVal < minPOC) {
         minPOC = reorder_output_queue[i]->PicOrderCntVal;
@@ -186,7 +186,7 @@ bool decoded_picture_buffer::flush_reorder_buffer()
 
 void decoded_picture_buffer::clear()
 {
-  for (int i=0;i<dpb.size();i++) {
+  for (size_t i=0;i<dpb.size();i++) {
     if (dpb[i]->PicOutputFlag ||
         dpb[i]->PicState != UnusedForReference)
       {
@@ -211,7 +211,7 @@ int decoded_picture_buffer::new_image(std::shared_ptr<const seq_parameter_set> s
   // --- search for a free slot in the DPB ---
 
   int free_image_buffer_idx = -DE265_ERROR_IMAGE_BUFFER_FULL;
-  for (int i=0;i<dpb.size();i++) {
+  for (size_t i=0;i<dpb.size();i++) {
     if (dpb[i]->can_be_released()) {
       dpb[i]->release(); /* TODO: this is surely not the best place to free the image, but
                             we have to do it here because releasing it in de265_release_image()

--- a/libde265/encoder/algo/coding-options.cc
+++ b/libde265/encoder/algo/coding-options.cc
@@ -110,7 +110,7 @@ void CodingOptions<node>::start(enum RateEstimationMethod rateMethod)
 template <class node>
 void CodingOptions<node>::compute_rdo_costs()
 {
-  for (int i=0;i<mOptions.size();i++) {
+  for (size_t i=0;i<mOptions.size();i++) {
     if (mOptions[i].computed) {
       //printf("compute_rdo_costs %d: %f\n",i, mOptions[i].mNode->rate);
       mOptions[i].rdoCost = mOptions[i].mNode->distortion + mECtx->lambda * mOptions[i].mNode->rate;
@@ -129,7 +129,7 @@ int CodingOptions<node>::find_best_rdo_index()
   bool  first=true;
   int   bestRDO=-1;
 
-  for (int i=0;i<mOptions.size();i++) {
+  for (size_t i=0;i<mOptions.size();i++) {
     if (mOptions[i].computed) {
       float cost = mOptions[i].rdoCost;
 
@@ -159,7 +159,7 @@ node* CodingOptions<node>::return_best_rdo_node()
 
   // delete all CBs except the best one
 
-  for (int i=0;i<mOptions.size();i++) {
+  for (size_t i=0;i<mOptions.size();i++) {
     if (i != bestRDO)
       {
         delete mOptions[i].mNode;

--- a/libde265/encoder/algo/tb-intrapredmode.cc
+++ b/libde265/encoder/algo/tb-intrapredmode.cc
@@ -464,7 +464,7 @@ Algo_TB_IntraPredMode_FastBrute::analyze(encoder_context* ectx,
     CodingOptions<enc_tb> options(ectx, tb, ctxModel);
     std::vector<CodingOption<enc_tb> >  option;
 
-    for (int i=0;i<distortions.size();i++) {
+    for (size_t i=0;i<distortions.size();i++) {
       enum IntraPredMode intraMode  = (IntraPredMode)distortions[i].first;
       if (!isPredModeEnabled(intraMode)) { continue; }
 

--- a/libde265/encoder/encoder-types.cc
+++ b/libde265/encoder/encoder-types.cc
@@ -638,7 +638,7 @@ const enc_pb_inter* CTBTreeMatrix::getPB(int x,int y) const
 void CTBTreeMatrix::writeReconstructionToImage(de265_image* img,
                                                const seq_parameter_set* sps) const
 {
-  for (int i=0;i<mCTBs.size();i++) {
+  for (size_t i=0;i<mCTBs.size();i++) {
     const enc_cb* cb = mCTBs[i];
     cb->writeReconstructionToImage(img, sps);
   }

--- a/libde265/encoder/encpicbuf.cc
+++ b/libde265/encoder/encpicbuf.cc
@@ -134,7 +134,7 @@ void image_data::set_references(int sps_index, // -1 -> custom
   //shdr.num_ref_idx_l1_active = l1.size();
 
   assert(l0.size() < MAX_NUM_REF_PICS);
-  for (int i=0;i<l0.size();i++) {
+  for (size_t i=0;i<l0.size();i++) {
     shdr.RefPicList[0][i] = l0[i];
   }
 
@@ -245,7 +245,7 @@ void encoder_picture_buffer::mark_encoding_finished(int frame_number)
 
 bool encoder_picture_buffer::have_more_frames_to_encode() const
 {
-  for (int i=0;i<mImages.size();i++) {
+  for (size_t i=0;i<mImages.size();i++) {
     if (mImages[i]->state < image_data::state_encoding) {
       return true;
     }
@@ -257,7 +257,7 @@ bool encoder_picture_buffer::have_more_frames_to_encode() const
 
 image_data* encoder_picture_buffer::get_next_picture_to_encode()
 {
-  for (int i=0;i<mImages.size();i++) {
+  for (size_t i=0;i<mImages.size();i++) {
     if (mImages[i]->state < image_data::state_encoding) {
       return mImages[i];
     }
@@ -269,7 +269,7 @@ image_data* encoder_picture_buffer::get_next_picture_to_encode()
 
 const image_data* encoder_picture_buffer::get_picture(int frame_number) const
 {
-  for (int i=0;i<mImages.size();i++) {
+  for (size_t i=0;i<mImages.size();i++) {
     if (mImages[i]->frame_number == frame_number)
       return mImages[i];
   }
@@ -281,7 +281,7 @@ const image_data* encoder_picture_buffer::get_picture(int frame_number) const
 
 image_data* encoder_picture_buffer::get_picture(int frame_number)
 {
-  for (int i=0;i<mImages.size();i++) {
+  for (size_t i=0;i<mImages.size();i++) {
     if (mImages[i]->frame_number == frame_number)
       return mImages[i];
   }
@@ -293,7 +293,7 @@ image_data* encoder_picture_buffer::get_picture(int frame_number)
 
 bool encoder_picture_buffer::has_picture(int frame_number) const
 {
-  for (int i=0;i<mImages.size();i++) {
+  for (size_t i=0;i<mImages.size();i++) {
     if (mImages[i]->frame_number == frame_number)
       return true;
   }

--- a/libde265/image.cc
+++ b/libde265/image.cc
@@ -511,7 +511,7 @@ void de265_image::release()
 
   // free slices
 
-  for (int i=0;i<slices.size();i++) {
+  for (size_t i=0;i<slices.size();i++) {
     delete slices[i];
   }
   slices.clear();

--- a/libde265/nal-parser.cc
+++ b/libde265/nal-parser.cc
@@ -181,7 +181,7 @@ NAL_Parser::~NAL_Parser()
 
   // free all NALs in free-list
 
-  for (int i=0;i<NAL_free_list.size();i++) {
+  for (size_t i=0;i<NAL_free_list.size();i++) {
     delete NAL_free_list[i];
   }
 }

--- a/libde265/sps.cc
+++ b/libde265/sps.cc
@@ -722,7 +722,7 @@ void seq_parameter_set::dump(int fd) const
 
   LOG1("num_short_term_ref_pic_sets : %d\n", ref_pic_sets.size());
 
-  for (int i = 0; i < ref_pic_sets.size(); i++) {
+  for (size_t i = 0; i < ref_pic_sets.size(); i++) {
     LOG1("ref_pic_set[ %2d ]: ",i);
     dump_compact_short_term_ref_pic_set(&ref_pic_sets[i], 16, fh);
   }


### PR DESCRIPTION
During compilation libde265 produces a number of -Wsign-compare warnings:

```
~/git/libde265/libde265/decctx.h: In member function ‘slice_unit* image_unit::get_next_slice_segment(slice_unit*) const’:
~/git/libde265/libde265/decctx.h:226:20: warning: comparison of integer expressions of different signedness: ‘int’ and ‘std::vector<slice_unit*>::size_type’ {aka ‘long unsigned int’} [-Wsign-compare]
  226 |     for (int i=0; i<slice_units.size()-1; i++) {
      |                   ~^~~~~~~~~~~~~~~~~~~~~
```

this PR resolves some of them. 

It replaces `int` with `size_t` for index variables and does not have a functional impact.