### PR TITLE
Fix SSE detection logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,14 +44,17 @@ if(CMAKE_COMPILER_IS_GNUCXX OR ${CMAKE_CXX_COMPILER_ID} MATCHES Clang)
   add_definitions(-Wall)
 endif()
 
+set(DISABLE_SSE ON)
 check_c_source_compiles(
-    "#if !defined(__x86_64) && !defined(__i386__) \\
-    && !defined(_M_IX86) && !defined(_M_AMD64)
-    #error not x86
-    #endif
-    int main(){return 0;}"
-    HAVE_X86)
-set(DISABLE_SSE "Disable SSE optimizations" ${HAVE_X86})
+  "#if !defined(__x86_64) && !defined(__i386__) \
+  && !defined(_M_IX86) && !defined(_M_AMD64)
+  #error not x86
+  #endif
+  int main(){return 0;}"
+  HAVE_X86)
+if (HAVE_X86)
+  set(DISABLE_SSE OFF)
+endif()
 
 option(BUILD_SHARED_LIBS "Build shared library" ON)
 if(NOT BUILD_SHARED_LIBS)


### PR DESCRIPTION
As detailed in https://github.com/strukturag/libde265/pull/411#pullrequestreview-1741175631, the current logic is completely broken.

This fixes it to match its intent, although this check probably belongs in the library CMakeLists where it's actually used if it's not going to be an option.