### PR TITLE
fix typos found by codespell

### DIFF
--- a/libde265/contextmodel.cc
+++ b/libde265/contextmodel.cc
@@ -92,7 +92,7 @@ void context_model_table::decouple()
 {
   if (D) printf("%p decouple (%p)\n",this,refcnt);
 
-  assert(refcnt); // not necessarily so, but we never use it on an unitialized object
+  assert(refcnt); // not necessarily so, but we never use it on an uninitialized object
 
   if (*refcnt > 1) {
     (*refcnt)--;
@@ -125,7 +125,7 @@ context_model_table& context_model_table::operator=(const context_model_table& s
 {
   if (D) printf("%p assign = %p\n",this,&src);
 
-  // assert(src.refcnt); // not necessarily so, but we never use it on an unitialized object
+  // assert(src.refcnt); // not necessarily so, but we never use it on an uninitialized object
 
   if (!src.refcnt) {
     release();

--- a/libde265/decctx.cc
+++ b/libde265/decctx.cc
@@ -1209,7 +1209,7 @@ de265_error decoder_context::decode_NAL(NAL_unit* nal)
 
   if (nal_hdr.nuh_layer_id > 0) {
     // Discard all NAL units with nuh_layer_id > 0
-    // These will have to be handeled by an SHVC decoder.
+    // These will have to be handled by an SHVC decoder.
     nal_parser.free_NAL_unit(nal);
     return DE265_OK;
   }

--- a/libde265/encoder/algo/cb-split.cc
+++ b/libde265/encoder/algo/cb-split.cc
@@ -31,7 +31,7 @@
 #include <iostream>
 
 
-// Utility function to encode all four children in a splitted CB.
+// Utility function to encode all four children in a split CB.
 // Children are coded with the specified algo_cb_split.
 enc_cb* Algo_CB_Split::encode_cb_split(encoder_context* ectx,
                                        context_model_table& ctxModel,

--- a/libde265/image.h
+++ b/libde265/image.h
@@ -428,7 +428,7 @@ public:
                                      void* userdata);
   */
 
-  uint8_t integrity; /* Whether an error occured while the image was decoded.
+  uint8_t integrity; /* Whether an error occurred while the image was decoded.
                         When generated, this is initialized to INTEGRITY_CORRECT,
                         and changed on decoding errors.
                       */

--- a/libde265/motion.cc
+++ b/libde265/motion.cc
@@ -389,7 +389,7 @@ void generate_inter_prediction_samples(base_context* ctx,
                  l,vi->mv[l].x,vi->mv[l].y,refPic->PicOrderCntVal);
 
 
-        // TODO: must predSamples stride really be nCS or can it be somthing smaller like nPbW?
+        // TODO: must predSamples stride really be nCS or can it be something smaller like nPbW?
 
         if (img->high_bit_depth(0)) {
           mc_luma(ctx, sps, vi->mv[l].x, vi->mv[l].y, xP,yP,
@@ -795,7 +795,7 @@ private:
 
   A maximum of 4 candidates are generated.
 
-  Note 1: For a CB splitted into two PBs, it does not make sense to merge the
+  Note 1: For a CB split into two PBs, it does not make sense to merge the
   second part to the parameters of the first part, since then, we could use 2Nx2N
   right away. -> Exclude this candidate.
 */

--- a/libde265/refpic.cc
+++ b/libde265/refpic.cc
@@ -79,7 +79,7 @@ void ref_pic_set::compute_derived_values()
    - as a list of the relative POC deltas themselves, or
    - by shifting an existing ref-pic-set by some number of frames
    When shifting an existing set, the frame 0 is also shifted as an additional reference frame.
-   When coding the ref-pic-sets in the SPS, predicition is always from the previous set.
+   When coding the ref-pic-sets in the SPS, prediction is always from the previous set.
    In the slice header, the ref-pic-set can use any previous set as reference.
  */
 bool read_short_term_ref_pic_set(error_queue* errqueue,

--- a/libde265/transform.cc
+++ b/libde265/transform.cc
@@ -653,7 +653,7 @@ void scale_coefficients(thread_context* tctx,
 
 //#define QUANT_IQUANT_SHIFT    20 // Q(QP%6) * IQ(QP%6) = 2^20
 #define QUANT_SHIFT           14 // Q(4) = 2^14
-//#define SCALE_BITS            15 // Inherited from TMuC, pressumably for fractional bit estimates in RDOQ
+//#define SCALE_BITS            15 // Inherited from TMuC, presumably for fractional bit estimates in RDOQ
 #define MAX_TR_DYNAMIC_RANGE  15 // Maximum transform dynamic range (excluding sign bit)
 
 

--- a/libde265/vui.cc
+++ b/libde265/vui.cc
@@ -187,8 +187,8 @@ de265_error video_usability_information::hrd_parameters(error_queue* errqueue, b
       fixed_pic_rate_within_cvs_flag[i] = true;
     }
 
-    low_delay_hrd_flag[i] = 0;// Infered to be 0 when not present
-    cpb_cnt_minus1[i] = 0;    // Infered to be 0 when not present
+    low_delay_hrd_flag[i] = 0;// Inferred to be 0 when not present
+    cpb_cnt_minus1[i] = 0;    // Inferred to be 0 when not present
 
     if (fixed_pic_rate_within_cvs_flag[i])
     {

--- a/libde265/x86/sse-dct.cc
+++ b/libde265/x86/sse-dct.cc
@@ -2114,7 +2114,7 @@ void ff_hevc_transform_16x16_add_8_sse4(uint8_t *_dst, const int16_t *coeffs,
 
 
                 r4 = _mm_unpackhi_epi64(m128Tmp0, m128Tmp1);    //1st half 2nd row
-                r6 = _mm_unpackhi_epi64(m128Tmp2, m128Tmp3);    //2nd hald 2nd row
+                r6 = _mm_unpackhi_epi64(m128Tmp2, m128Tmp3);    //2nd half 2nd row
 
                 m128Tmp0 = _mm_unpackhi_epi32(E0l, E1l);
                 m128Tmp1 = _mm_unpackhi_epi32(E2l, E3l);
@@ -4924,7 +4924,7 @@ void ff_hevc_transform_32x32_add_8_sse4(uint8_t *_dst, const int16_t *coeffs,
                 m128iS14= _mm_unpackhi_epi64(m128Tmp4,m128Tmp5); //third quarter
                 m128iS15= _mm_unpackhi_epi64(m128Tmp6,m128Tmp7); //last quarter
 
-                //fith row
+                //fifth row
 
                 m128Tmp0= _mm_unpacklo_epi32(E0h,E1h);
                 m128Tmp1= _mm_unpacklo_epi32(E2h,E3h);

--- a/sherlock265/README
+++ b/sherlock265/README
@@ -7,7 +7,7 @@ CB - Show Coding Block quadtree structure. Prediction modes are
      PBs for prediction and TBs for residual transforms.
 
 PB - Show Prediction Block structure. CB blocks may be further
-     subdivided, possibly using asymetric partitionings. This is
+     subdivided, possibly using asymmetric partitionings. This is
      the level on which motion-compensation and intra-prediction is
      performed.
 


### PR DESCRIPTION
All typos are in code comments.