### PR TITLE
dec265: Resize window if image resolution changes mid-stream.

### DIFF
--- a/dec265/dec265.cc
+++ b/dec265/dec265.cc
@@ -266,17 +266,19 @@ bool display_sdl(const struct de265_image* img)
 
   de265_chroma chroma = de265_get_chroma_format(img);
 
+  enum SDL_YUV_Display::SDL_Chroma sdlChroma;
+  switch (chroma) {
+  case de265_chroma_420:  sdlChroma = SDL_YUV_Display::SDL_CHROMA_420;  break;
+  case de265_chroma_422:  sdlChroma = SDL_YUV_Display::SDL_CHROMA_422;  break;
+  case de265_chroma_444:  sdlChroma = SDL_YUV_Display::SDL_CHROMA_444;  break;
+  case de265_chroma_mono: sdlChroma = SDL_YUV_Display::SDL_CHROMA_MONO; break;
+  }
+
   if (!sdl_active) {
     sdl_active=true;
-    enum SDL_YUV_Display::SDL_Chroma sdlChroma;
-    switch (chroma) {
-    case de265_chroma_420:  sdlChroma = SDL_YUV_Display::SDL_CHROMA_420;  break;
-    case de265_chroma_422:  sdlChroma = SDL_YUV_Display::SDL_CHROMA_422;  break;
-    case de265_chroma_444:  sdlChroma = SDL_YUV_Display::SDL_CHROMA_444;  break;
-    case de265_chroma_mono: sdlChroma = SDL_YUV_Display::SDL_CHROMA_MONO; break;
-    }
-
     sdlWin.init(width,height, sdlChroma);
+  } else {
+    sdlWin.resize(width,height, sdlChroma);
   }
 
   int stride,chroma_stride;

--- a/dec265/sdl.hh
+++ b/dec265/sdl.hh
@@ -39,6 +39,7 @@ public:
   };
 
   bool init(int frame_width, int frame_height, enum SDL_Chroma chroma = SDL_CHROMA_420);
+  bool resize(int frame_width, int frame_height, enum SDL_Chroma chroma = SDL_CHROMA_420);
   void display(const unsigned char *Y, const unsigned char *U, const unsigned char *V,
                int stride, int chroma_stride);
   void close();


### PR DESCRIPTION
Fixes the first example from #460 

@farindk the stream changes image information as follows:
```
Image: 352x288 bpp_y=8 bpp_c=8
Image: 512x256 bpp_y=8 bpp_c=8
Image: 512x256 bpp_y=14 bpp_c=8
Image: 512x256 bpp_y=14 bpp_c=8
```

I fixed the crash by resizing the SDL window if the image size in the stream changes.

The second example still crashes on the fist image in the stream, I haven't figured out why yet. Looks like the memory returned from `SDL_LockTexture`  is too small for `display444as420`  later even through the width/height seem to match from what was created.