### PR TITLE
allow build with cmake-4.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.3.2)
+cmake_minimum_required (VERSION 3.3.2...3.10)
 
 project (libde265
     LANGUAGES C CXX


### PR DESCRIPTION
use min...max syntax to allow build with newer cmake. 

ref: https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html

fixes #470