### PR TITLE
libde265: Use process-local sync primitives on Windows.

### DIFF
--- a/libde265/image.cc
+++ b/libde265/image.cc
@@ -734,7 +734,7 @@ void de265_image::thread_finishes(const thread_task* task)
   assert(nThreadsRunning >= 0);
 
   if (nThreadsFinished==nThreadsTotal) {
-    de265_cond_broadcast(&finished_cond, &mutex);
+    de265_cond_broadcast(&finished_cond);
   }
 
   de265_mutex_unlock(&mutex);

--- a/libde265/threads.cc
+++ b/libde265/threads.cc
@@ -66,20 +66,15 @@ int  de265_thread_create(de265_thread* t, LPTHREAD_START_ROUTINE start_routine, 
 }
 void de265_thread_join(de265_thread t) { WaitForSingleObject(t, INFINITE); }
 void de265_thread_destroy(de265_thread* t) { CloseHandle(*t); *t = NULL; }
-void de265_mutex_init(de265_mutex* m) { *m = CreateMutex(NULL, FALSE, NULL); }
-void de265_mutex_destroy(de265_mutex* m) { CloseHandle(*m); }
-void de265_mutex_lock(de265_mutex* m) { WaitForSingleObject(*m, INFINITE); }
-void de265_mutex_unlock(de265_mutex* m) { ReleaseMutex(*m); }
-void de265_cond_init(de265_cond* c) { win32_cond_init(c); }
-void de265_cond_destroy(de265_cond* c) { win32_cond_destroy(c); }
-void de265_cond_broadcast(de265_cond* c,de265_mutex* m)
-{
-  de265_mutex_lock(m);
-  win32_cond_broadcast(c);
-  de265_mutex_unlock(m);
-}
-void de265_cond_wait(de265_cond* c,de265_mutex* m) { win32_cond_wait(c,m); }
-void de265_cond_signal(de265_cond* c) { win32_cond_signal(c); }
+void de265_mutex_init(de265_mutex* m) { InitializeCriticalSection(m); }
+void de265_mutex_destroy(de265_mutex* m) { DeleteCriticalSection(m); }
+void de265_mutex_lock(de265_mutex* m) { EnterCriticalSection(m); }
+void de265_mutex_unlock(de265_mutex* m) { LeaveCriticalSection(m); }
+void de265_cond_init(de265_cond* c) { InitializeConditionVariable(c); }
+void de265_cond_destroy(de265_cond* c) { }
+void de265_cond_broadcast(de265_cond* c,de265_mutex* m) { WakeAllConditionVariable(c); }
+void de265_cond_wait(de265_cond* c,de265_mutex* m) { SleepConditionVariableCS(c, m, INFINITE); }
+void de265_cond_signal(de265_cond* c) { WakeConditionVariable(c); }
 #endif // _WIN32
 
 

--- a/libde265/threads.cc
+++ b/libde265/threads.cc
@@ -47,7 +47,7 @@ void de265_mutex_lock(de265_mutex* m) { pthread_mutex_lock(m); }
 void de265_mutex_unlock(de265_mutex* m) { pthread_mutex_unlock(m); }
 void de265_cond_init(de265_cond* c) { pthread_cond_init(c,NULL); }
 void de265_cond_destroy(de265_cond* c) { pthread_cond_destroy(c); }
-void de265_cond_broadcast(de265_cond* c,de265_mutex* m) { pthread_cond_broadcast(c); }
+void de265_cond_broadcast(de265_cond* c) { pthread_cond_broadcast(c); }
 void de265_cond_wait(de265_cond* c,de265_mutex* m) { pthread_cond_wait(c,m); }
 void de265_cond_signal(de265_cond* c) { pthread_cond_signal(c); }
 #else  // _WIN32
@@ -72,7 +72,7 @@ void de265_mutex_lock(de265_mutex* m) { EnterCriticalSection(m); }
 void de265_mutex_unlock(de265_mutex* m) { LeaveCriticalSection(m); }
 void de265_cond_init(de265_cond* c) { InitializeConditionVariable(c); }
 void de265_cond_destroy(de265_cond* c) { }
-void de265_cond_broadcast(de265_cond* c,de265_mutex* m) { WakeAllConditionVariable(c); }
+void de265_cond_broadcast(de265_cond* c) { WakeAllConditionVariable(c); }
 void de265_cond_wait(de265_cond* c,de265_mutex* m) { SleepConditionVariableCS(c, m, INFINITE); }
 void de265_cond_signal(de265_cond* c) { WakeConditionVariable(c); }
 #endif // _WIN32
@@ -114,7 +114,7 @@ void de265_progress_lock::set_progress(int progress)
   if (progress>mProgress) {
     mProgress = progress;
 
-    de265_cond_broadcast(&cond, &mutex);
+    de265_cond_broadcast(&cond);
   }
 
   de265_mutex_unlock(&mutex);
@@ -125,7 +125,7 @@ void de265_progress_lock::increase_progress(int progress)
   de265_mutex_lock(&mutex);
 
   mProgress += progress;
-  de265_cond_broadcast(&cond, &mutex);
+  de265_cond_broadcast(&cond);
 
   de265_mutex_unlock(&mutex);
 }
@@ -282,7 +282,7 @@ void stop_thread_pool(thread_pool* pool)
   pool->stopped = true;
   de265_mutex_unlock(&pool->mutex);
 
-  de265_cond_broadcast(&pool->cond_var, &pool->mutex);
+  de265_cond_broadcast(&pool->cond_var);
 
   for (int i=0;i<pool->num_threads;i++) {
     de265_thread_join(pool->thread[i]);

--- a/libde265/threads.h
+++ b/libde265/threads.h
@@ -66,7 +66,7 @@ void de265_mutex_lock(de265_mutex* m);
 void de265_mutex_unlock(de265_mutex* m);
 void de265_cond_init(de265_cond* c);
 void de265_cond_destroy(de265_cond* c);
-void de265_cond_broadcast(de265_cond* c, de265_mutex* m);
+void de265_cond_broadcast(de265_cond* c);
 void de265_cond_wait(de265_cond* c,de265_mutex* m);
 void de265_cond_signal(de265_cond* c);
 

--- a/libde265/threads.h
+++ b/libde265/threads.h
@@ -49,8 +49,8 @@ typedef pthread_cond_t   de265_cond;
 #endif
 
 typedef HANDLE              de265_thread;
-typedef HANDLE              de265_mutex;
-typedef win32_cond_t        de265_cond;
+typedef CRITICAL_SECTION    de265_mutex;
+typedef CONDITION_VARIABLE  de265_cond;
 #endif  // _WIN32
 
 #ifndef _WIN32


### PR DESCRIPTION
This issue came up when running libheif+libde265 using Wine,
manifesting as severe performance degradation.

Windows-specific code is using Win32 mutex for cross thread
synchronization, both directly and to implement conditional variables.
This is problematic on Wine because it causes global state change
exchange on every mutex access. On Wine NT objects state is
managed in a separate resident process, each user process communicates with it
to update object state. High frequency access is going to cause
performance problems as a result. Performance will degarde further
if multiple process are running at the same time, each using same
large amount of such calls.

Proposed change is using API that is available since Windows Vista.