### PR TITLE
Bump CMake minimum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5.0)
+cmake_minimum_required (VERSION 3.16.3)
 
 project (libde265
     LANGUAGES C CXX


### PR DESCRIPTION
CMake 4 does not accept <= 3.5 anymore (although it is claiming < 3.5 only) so bump it to 3.16.3, similar to libheif's minimal requirement

Fixes #478