### PR TITLE
Add support for compiling Windows ARM64EC

### DIFF
--- a/libde265/CMakeLists.txt
+++ b/libde265/CMakeLists.txt
@@ -94,7 +94,8 @@ add_subdirectory (encoder)
 
 check_c_source_compiles(
   "#if !defined(__x86_64) && !defined(__i386__) \
-  && !defined(_M_IX86) && !defined(_M_AMD64)
+  && !defined(_M_IX86) && !defined(_M_AMD64) \
+  || defined(_M_ARM64EC) || defined(_ARM64EC_)
   #error not x86
   #endif
   int main(){return 0;}"


### PR DESCRIPTION
PR Description:

- ARM64EC (Emulation Compatible) is an application binary interface (ABI) for applications running on ARM-based Windows 11 devices. Code built for ARM64EC can interoperate with x64 code running under emulation, leveraging the native performance of ARM hardware.
- This PR adds support for building the libde265 library targeting Windows ARM64EC. The changes include conditional guards to exclude x64-specific code paths, enabling successful compilation for the ARM64EC architecture.