### PR TITLE
Clean up Clang warning unused-but-set-variable

### DIFF
--- a/libde265/decctx.cc
+++ b/libde265/decctx.cc
@@ -1750,7 +1750,8 @@ void decoder_context::run_postprocessing_filters_parallel(image_unit* imgunit)
     //apply_sample_adaptive_offset(img);
   }
 
-  img->wait_for_completion();
+  if (waitForCompletion)
+    img->wait_for_completion();
 }
 
 /*


### PR DESCRIPTION
```
libde265/decctx.cc:1741:8: warning: variable 'waitForCompletion' set but not used [-Wunused-but-set-variable]
 1741 |   bool waitForCompletion = false;
      |        ^
```