### PR TITLE
Pin all GitHub actions to a specific commit and added a cooldown to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,5 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
+    cooldown:
+      default-days: 7
     schedule:
       interval: "daily"

--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -11,10 +11,10 @@ jobs:
     env: ${{ matrix.env }}
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
     - name: Checkout sample streams
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       with:
         repository: strukturag/libde265-data
         path: libde265-data

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,10 @@ jobs:
     env: ${{ matrix.env }}
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
     - name: Checkout sample streams
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       with:
         repository: strukturag/libde265-data
         path: libde265-data

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -10,10 +10,10 @@ jobs:
     env:
       TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
     - name: Cache Coverity build tool
-      uses: actions/cache@v5
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 #v5.0.4
       with:
         path: |
           coverity_tool.tar.gz

--- a/.github/workflows/decode.yml
+++ b/.github/workflows/decode.yml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-22.04
     continue-on-error: true
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
     - name: Checkout sample streams
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       with:
         repository: strukturag/libde265-data
         path: libde265-data

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
   licensecheck:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -12,10 +12,10 @@ jobs:
     env: ${{ matrix.env }}
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
     - name: Checkout sample streams
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       with:
         repository: strukturag/libde265-data
         path: libde265-data

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -14,10 +14,10 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
     - name: Checkout sample streams
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
       with:
         repository: strukturag/libde265-data
         path: libde265-data


### PR DESCRIPTION
This PR pins all the github actions to a specific commit and adds a cooldown to dependabot.yml. This means that new versions of actions will only be updated after 7 days unless there is a security incident and they need to be updated immediately.