### PR TITLE
ci: add permissions: read-all to all workflows (7 files)

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -2,6 +2,8 @@ name: arm
 
 on: [push, pull_request]
 
+permissions: read-all
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: build
 
 on: [push, pull_request]
 
+permissions: read-all
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [ coverity ]
 
+permissions: read-all
+
 jobs:
   scan:
     runs-on: ubuntu-22.04

--- a/.github/workflows/decode.yml
+++ b/.github/workflows/decode.yml
@@ -2,6 +2,8 @@ name: decode
 
 on: [push, pull_request]
 
+permissions: read-all
+
 jobs:
   streams:
     strategy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,8 @@ name: lint
 
 on: [push, pull_request]
 
+permissions: read-all
+
 jobs:
   licensecheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -2,6 +2,8 @@ name: mingw
 
 on: [push, pull_request]
 
+permissions: read-all
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -2,6 +2,8 @@ name: osx
 
 on: [push, pull_request]
 
+permissions: read-all
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
## Summary

All 7 CI workflows are missing top-level `permissions` declarations. Without this, jobs run with the default broad token permissions (contents: write, packages: write, etc.), violating the principle of least privilege.

**Changes:**
- Add `permissions: read-all` at the workflow level for all 7 workflows

Action SHA pins were already present in most workflows; this PR adds only the missing `permissions` declarations.