### PR TITLE
sei: fix payload_size overflow guard comparing wrong variable

### DIFF
--- a/libde265/sei.cc
+++ b/libde265/sei.cc
@@ -388,7 +388,7 @@ de265_error read_sei(bitreader* reader, sei_message* sei, bool suffix, const seq
     {
       uint32_t byte = reader->get_bits(8);
 
-      if (MAX_SEI_SIZE - byte < payload_type) {
+      if (MAX_SEI_SIZE - byte < payload_size) {
         return DE265_ERROR_CANNOT_PROCESS_SEI;
       }
 


### PR DESCRIPTION
In `read_sei()` (libde265/sei.cc), the 0xFF-continuation accumulation loop for `payload_size` guards against integer overflow with:

```cpp
if (MAX_SEI_SIZE - byte < payload_type) {
  return DE265_ERROR_CANNOT_PROCESS_SEI;
}
```

but this compares against `payload_type` (a `uint16_t` computed by the preceding, independent loop) instead of `payload_size` (the `uint32_t` actually being accumulated in this loop). Since `MAX_SEI_SIZE` is `0xFFFFFFFF`, and `payload_type` can never exceed 65535, `MAX_SEI_SIZE - byte` is always far larger than any possible `payload_type`, so this guard can never trigger — it is unconditionally dead code, regardless of input.

This means `payload_size` can silently wrap around (via repeated `0xFF` continuation bytes) instead of returning `DE265_ERROR_CANNOT_PROCESS_SEI` as the guard intends.

This looks like a copy/paste slip from the guard just above it (which correctly compares `payload_type` against `std::numeric_limits<uint16_t>::max()`), introduced in 5d866cc ("modernize C++ code").

Fix: compare against `payload_size`, matching the value actually being accumulated in this loop.

Verified with a standalone harness that reproduces the wraparound with the original code and confirms the fix rejects it, plus a full local build (`libde265.a`) with no new warnings.