### PR TITLE
add "none" as DE265_LOG_LEVEL option

### DIFF
--- a/libde265/CMakeLists.txt
+++ b/libde265/CMakeLists.txt
@@ -125,7 +125,7 @@ write_basic_package_version_file(libde265-config-version.cmake COMPATIBILITY Exa
 
 # --- debug output
 
-set(LOG_LEVELS error info debug trace)
+set(LOG_LEVELS none error info debug trace)
 set(DE265_LOG_LEVEL "error" CACHE STRING "Log level (${LOG_LEVELS})")
 
 set_property(CACHE DE265_LOG_LEVEL PROPERTY STRINGS ${LOG_LEVELS})
@@ -133,7 +133,10 @@ if (NOT DE265_LOG_LEVEL IN_LIST LOG_LEVELS)
     message(FATAL_ERROR "DE265_LOG_LEVEL has to be one of: ${LOG_LEVELS}")
 endif ()
 
-if (DE265_LOG_LEVEL MATCHES "error")
+if (DE265_LOG_LEVEL STREQUAL "none")
+    # No logging compiled in — all logerror/loginfo/etc. calls become no-op
+    # macros via the #else branches in libde265/util.h.
+elseif (DE265_LOG_LEVEL MATCHES "error")
     target_compile_definitions(de265 PRIVATE DE265_LOG_ERROR)
 elseif (DE265_LOG_LEVEL MATCHES "info")
     target_compile_definitions(de265 PRIVATE DE265_LOG_ERROR DE265_LOG_INFO)


### PR DESCRIPTION
Consumers linking libde265 through libheif don't need the stderr logging — decode errors already come back through the API. With the current default `DE265_LOG_LEVEL=error`, TSan flags races on the unsynchronized log statics in `util.cc` (`current_poc`, `disable_log[]`, `verbosity`) when the caller decodes in parallel: libheif's grid decoder splits work across `std::thread`s and they all race on `log_set_current_POC`.

Adds `none` to `LOG_LEVELS`. With `-DDE265_LOG_LEVEL=none` no `DE265_LOG_*` is defined and the `log_*` calls expand to no-op macros via the existing `#else` branches in `util.h`. Default stays `error`, so existing configs are unaffected.