### PR TITLE
Fix potential security issues in NAL_unit::set_data()

### DIFF
--- a/libde265/nal-parser.cc
+++ b/libde265/nal-parser.cc
@@ -99,10 +99,15 @@ LIBDE265_CHECK_RESULT bool NAL_unit::append(const unsigned char* in_data, int n)
 
 bool LIBDE265_CHECK_RESULT NAL_unit::set_data(const unsigned char* in_data, int n)
 {
+  if (n < 0) {
+    return false;
+  }
   if (!resize(n)) {
     return false;
   }
-  memcpy(nal_data, in_data, n);
+  if (n > 0) {
+    memcpy(nal_data, in_data, n);
+  }
   data_size = n;
   return true;
 }


### PR DESCRIPTION
1. Fix UBSAN: when n=0 is passed to fresh NAL_unit, resize(0) returns true without allocating buffer. memcpy() receives nullptr destination with size zero, which is undefined behavior. Skip memcpy() for n == 0 while keeping n=0 return‑true semantics for empty NAL units.

> Reproduction steps:
> git clone https://github.com/strukturag/libde265.git
> cd libde265
> mkdir build && cd build
> export CC=afl-clang-fast CXX=afl-clang-fast++
> cmake .. -DCMAKE_C_FLAGS="-fsanitize=address,undefined -g" \
>          -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -g"
> make -j$(nproc)
> 
> [AFL++ 35efb54a0832] ~ # /usr/local/bin/dec265 -q -n -0 ./poc_file 
> /root/fuzz_libde265/libde265_noasan/libde265/nal-parser.cc:105:10: runtime error: null pointer passed as argument 1, which is declared to never be null
> /usr/include/string.h:44:28: note: nonnull attribute specified here
> SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /root/fuzz_libde265/libde265_noasan/libde265/nal-parser.cc:105:10 
> poc_file: 
> [poc_file.zip](https://github.com/user-attachments/files/31289062/poc_file.zip)

2. Reject negative n at entry. resize() does not validate new_size >= 0.
Negative values bypass resize checks, can trigger size_t conversion overflow
leading to heap‑buffer‑overflow and negative data_size. Return false for n < 0."