### PR TITLE
Fix 4x4 IDST residual clipping that broke 16-bit decoding

### DIFF
--- a/libde265/fallback-dct.cc
+++ b/libde265/fallback-dct.cc
@@ -324,7 +324,8 @@ void transform_4x4_luma_add_8_fallback(uint8_t *dst, const int16_t *coeffs, ptrd
         sum += mat_8_357[j][i] * g[y][j];
       }
 
-      int out = Clip3(-32768,32767, (sum+rndH)>>postShift);
+      // no clipping to -32768;32767 required
+      int out = (sum+rndH)>>postShift;
 
       dst[y*stride+i] = Clip1_8bit(dst[y*stride+i] + out);
 
@@ -395,7 +396,9 @@ void transform_4x4_luma_add_16_fallback(uint16_t *dst, const int16_t *coeffs, pt
         sum += mat_8_357[j][i] * g[y][j];
       }
 
-      int out = Clip3(-32768,32767, (sum+rndH)>>postShift);
+      // no clipping to -32768;32767 required
+      // (at bit depth 16 the residual needs 17 bits and clipping breaks it)
+      int out = (sum+rndH)>>postShift;
 
       dst[y*stride+i] = Clip_BitDepth(dst[y*stride+i] + out, bit_depth);
 


### PR DESCRIPTION
The horizontal pass of `transform_4x4_luma_add_{8,16}_fallback` clipped its output to [-32768,32767]. That output is the residual, not a coefficient. (8.6.4.2) bounds the intermediate samples of the *vertical* pass to sixteen bits, which that pass already does; the residual it feeds is not bounded there, and at bit depth 16 it needs seventeen bits.

7c99637f ("remove unnecessary clipping after DCT") took the same clipping out of the DCT paths, but the two DST paths were missed. DST-VII is used only by 4x4 intra luma blocks, so the damage was confined to those: any such block whose residual left +-32767 decoded wrong, and the error then propagated through intra prediction into everything predicted from it. Depths up to 15 are unaffected, the residual still fitting.

Verified against HM 18.0 built with `RExt__HIGH_BIT_DEPTH_SUPPORT`, which a stock HM needs before it will decode 16-bit at all. On a 96x64 16-bit intra stream that exercises 4x4 luma TUs, dec265 differed from HM on 2122 of 9216 samples before and is identical after, with and without `--noaccel`. Depths 9, 11, 13, 14 and 15 are identical either way. testdata/girlshy.h265 decodes identically to HM over all 75 frames, the 8-bit change being a no-op: there the shift leaves the residual far inside the bound.

**Reproducer** – no bitstream needed:
fallback-dct.cc already has a correct implementation of the same transform in `transform_idst_4x4_fallback`, and the two disagree. One DC coefficient is enough.

```cc
// Build: c++ -I. -o repro repro.cc libde265/fallback-dct.cc
#include "libde265/fallback-dct.h"
#include <stdio.h>
#include <stdint.h>
#include <stdlib.h>

int main()
{
  int16_t coeffs[16] = {0};
  coeffs[0] = 16384;                // one DC coefficient, well inside int16

  int32_t residual[16];             // residual path (transform_idst_4x4): no clipping
  transform_idst_4x4_fallback(residual, coeffs, 20-16, 15);

  uint16_t dst[16] = {0};           // prediction = 0, so dst should equal residual
  transform_4x4_luma_add_16_fallback(dst, coeffs, 4, 16);

  int peak = 0, disagree = 0;
  for (int i=0;i<16;i++) {
    if (abs(residual[i]) > abs(residual[peak])) peak = i;
    if ((int32_t)dst[i] != residual[i]) disagree++;
  }
  printf("largest residual in the block: expected %d, got %u\n",
         residual[peak], (unsigned)dst[peak]);
  printf("%d of 16 samples disagree\n", disagree);
  return disagree != 0;
}
```

**Result:**
```
before:  largest residual in the block: expected 56448, got 32767
         6 of 16 samples disagree
after:   largest residual in the block: expected 56448, got 56448
         0 of 16 samples disagree
```

The code in this PR was created with the help of an LLM.