### PR TITLE
Fix motion compensation for bit depths 13 to 16

### DIFF
--- a/libde265/acceleration.h
+++ b/libde265/acceleration.h
@@ -25,6 +25,8 @@
 #include <stdint.h>
 #include <assert.h>
 
+#include "fallback-motion.h"
+
 
 struct acceleration_functions
 {
@@ -78,6 +80,25 @@ struct acceleration_functions
                          int w,int o,int log2WD, int bit_depth) const;
   void put_weighted_bipred(void *_dst, ptrdiff_t dststride,
                            const int16_t *src1, const int16_t *src2, ptrdiff_t srcstride,
+                           int width, int height,
+                           int w1,int o1, int w2,int o2, int log2WD, int bit_depth) const;
+
+  // int32_t prediction samples (bit depths above MC_MAX_BIT_DEPTH_INT16), fallback only
+
+  void put_weighted_pred_avg(void *_dst, ptrdiff_t dststride,
+                             const int32_t *src1, const int32_t *src2, ptrdiff_t srcstride,
+                             int width, int height, int bit_depth) const;
+
+  void put_unweighted_pred(void *_dst, ptrdiff_t dststride,
+                           const int32_t *src, ptrdiff_t srcstride,
+                           int width, int height, int bit_depth) const;
+
+  void put_weighted_pred(void *_dst, ptrdiff_t dststride,
+                         const int32_t *src, ptrdiff_t srcstride,
+                         int width, int height,
+                         int w,int o,int log2WD, int bit_depth) const;
+  void put_weighted_bipred(void *_dst, ptrdiff_t dststride,
+                           const int32_t *src1, const int32_t *src2, ptrdiff_t srcstride,
                            int width, int height,
                            int w1,int o1, int w2,int o2, int log2WD, int bit_depth) const;
 
@@ -136,6 +157,25 @@ struct acceleration_functions
   void put_hevc_qpel(int16_t *dst, ptrdiff_t dststride,
                      const void *src, ptrdiff_t srcstride, int width, int height,
                      int16_t* mcbuffer, int dX,int dY, int bit_depth) const;
+
+  // int32_t prediction samples (bit depths above MC_MAX_BIT_DEPTH_INT16), fallback only
+
+  void put_hevc_epel(int32_t *dst, ptrdiff_t dststride,
+                     const void *src, ptrdiff_t srcstride, int width, int height,
+                     int mx, int my, int32_t* mcbuffer, int bit_depth) const;
+  void put_hevc_epel_h(int32_t *dst, ptrdiff_t dststride,
+                       const void *src, ptrdiff_t srcstride, int width, int height,
+                       int mx, int my, int32_t* mcbuffer, int bit_depth) const;
+  void put_hevc_epel_v(int32_t *dst, ptrdiff_t dststride,
+                       const void *src, ptrdiff_t srcstride, int width, int height,
+                       int mx, int my, int32_t* mcbuffer, int bit_depth) const;
+  void put_hevc_epel_hv(int32_t *dst, ptrdiff_t dststride,
+                        const void *src, ptrdiff_t srcstride, int width, int height,
+                        int mx, int my, int32_t* mcbuffer, int bit_depth) const;
+
+  void put_hevc_qpel(int32_t *dst, ptrdiff_t dststride,
+                     const void *src, ptrdiff_t srcstride, int width, int height,
+                     int32_t* mcbuffer, int dX,int dY, int bit_depth) const;
 
 
   // --- inverse transforms ---
@@ -366,6 +406,93 @@ inline void acceleration_functions::put_hevc_qpel(int16_t *dst, ptrdiff_t dststr
     put_hevc_qpel_8[dX][dY](dst,dststride,(const uint8_t*)src,srcstride,width,height,mcbuffer);
   else
     put_hevc_qpel_16[dX][dY](dst,dststride,(const uint16_t*)src,srcstride,width,height,mcbuffer, bit_depth);
+}
+
+
+inline void acceleration_functions::put_weighted_pred_avg(void* _dst, ptrdiff_t dststride,
+                                                          const int32_t *src1, const int32_t *src2, ptrdiff_t srcstride,
+                                                          int width, int height, int bit_depth) const
+{
+  if (bit_depth <= 8)
+    put_weighted_pred_avg_fallback((uint8_t*)_dst,dststride,src1,src2,srcstride,width,height,bit_depth);
+  else
+    put_weighted_pred_avg_fallback((uint16_t*)_dst,dststride,src1,src2,srcstride,width,height,bit_depth);
+}
+
+inline void acceleration_functions::put_unweighted_pred(void* _dst, ptrdiff_t dststride,
+                                                        const int32_t *src, ptrdiff_t srcstride,
+                                                        int width, int height, int bit_depth) const
+{
+  if (bit_depth <= 8)
+    put_unweighted_pred_fallback((uint8_t*)_dst,dststride,src,srcstride,width,height,bit_depth);
+  else
+    put_unweighted_pred_fallback((uint16_t*)_dst,dststride,src,srcstride,width,height,bit_depth);
+}
+
+inline void acceleration_functions::put_weighted_pred(void* _dst, ptrdiff_t dststride,
+                                                      const int32_t *src, ptrdiff_t srcstride,
+                                                      int width, int height,
+                                                      int w,int o,int log2WD, int bit_depth) const
+{
+  if (bit_depth <= 8)
+    put_weighted_pred_fallback((uint8_t*)_dst,dststride,src,srcstride,width,height,w,o,log2WD,bit_depth);
+  else
+    put_weighted_pred_fallback((uint16_t*)_dst,dststride,src,srcstride,width,height,w,o,log2WD,bit_depth);
+}
+
+inline void acceleration_functions::put_weighted_bipred(void* _dst, ptrdiff_t dststride,
+                                                        const int32_t *src1, const int32_t *src2, ptrdiff_t srcstride,
+                                                        int width, int height,
+                                                        int w1,int o1, int w2,int o2, int log2WD, int bit_depth) const
+{
+  if (bit_depth <= 8)
+    put_weighted_bipred_fallback((uint8_t*)_dst,dststride,src1,src2,srcstride, width,height, w1,o1,w2,o2,log2WD,bit_depth);
+  else
+    put_weighted_bipred_fallback((uint16_t*)_dst,dststride,src1,src2,srcstride, width,height, w1,o1,w2,o2,log2WD,bit_depth);
+}
+
+inline void acceleration_functions::put_hevc_epel(int32_t *dst, ptrdiff_t dststride,
+                                                  const void *src, ptrdiff_t srcstride, int width, int height,
+                                                  int mx, int my, int32_t* mcbuffer, int bit_depth) const
+{
+  if (bit_depth <= 8)
+    put_epel_32_fallback(dst,dststride,(const uint8_t*)src,srcstride,width,height,bit_depth);
+  else
+    put_epel_32_fallback(dst,dststride,(const uint16_t*)src,srcstride,width,height,bit_depth);
+}
+
+inline void acceleration_functions::put_hevc_epel_h(int32_t *dst, ptrdiff_t dststride,
+                                                    const void *src, ptrdiff_t srcstride, int width, int height,
+                                                    int mx, int my, int32_t* mcbuffer, int bit_depth) const
+{
+  put_hevc_epel_hv(dst,dststride,src,srcstride,width,height,mx,my,mcbuffer,bit_depth);
+}
+
+inline void acceleration_functions::put_hevc_epel_v(int32_t *dst, ptrdiff_t dststride,
+                                                    const void *src, ptrdiff_t srcstride, int width, int height,
+                                                    int mx, int my, int32_t* mcbuffer, int bit_depth) const
+{
+  put_hevc_epel_hv(dst,dststride,src,srcstride,width,height,mx,my,mcbuffer,bit_depth);
+}
+
+inline void acceleration_functions::put_hevc_epel_hv(int32_t *dst, ptrdiff_t dststride,
+                                                     const void *src, ptrdiff_t srcstride, int width, int height,
+                                                     int mx, int my, int32_t* mcbuffer, int bit_depth) const
+{
+  if (bit_depth <= 8)
+    put_epel_hv_fallback(dst,dststride,(const uint8_t*)src,srcstride,width,height,mx,my,mcbuffer,bit_depth);
+  else
+    put_epel_hv_fallback(dst,dststride,(const uint16_t*)src,srcstride,width,height,mx,my,mcbuffer,bit_depth);
+}
+
+inline void acceleration_functions::put_hevc_qpel(int32_t *dst, ptrdiff_t dststride,
+                                                  const void *src, ptrdiff_t srcstride, int width, int height,
+                                                  int32_t* mcbuffer, int dX,int dY, int bit_depth) const
+{
+  if (bit_depth <= 8)
+    put_qpel_32_fallback(dst,dststride,(const uint8_t*)src,srcstride,width,height,mcbuffer,dX,dY,bit_depth);
+  else
+    put_qpel_32_fallback(dst,dststride,(const uint16_t*)src,srcstride,width,height,mcbuffer,dX,dY,bit_depth);
 }
 
 template <> inline void acceleration_functions::transform_skip<uint8_t>(uint8_t *dst, const int16_t *coeffs,ptrdiff_t stride, int bit_depth) const { transform_skip_8(dst,coeffs,stride); }

--- a/libde265/fallback-motion.cc
+++ b/libde265/fallback-motion.cc
@@ -161,9 +161,10 @@ void put_weighted_pred_avg_8_fallback(uint8_t *dst, ptrdiff_t dststride,
 
 
 
-void put_unweighted_pred_16_fallback(uint16_t *dst, ptrdiff_t dststride,
-                                     const int16_t *src, ptrdiff_t srcstride,
-                                     int width, int height, int bit_depth)
+template <class pixel_t, class inter_t>
+void put_unweighted_pred_fallback(pixel_t *dst, ptrdiff_t dststride,
+                                    const inter_t *src, ptrdiff_t srcstride,
+                                    int width, int height, int bit_depth)
 {
   // shift1 per HEVC v2 (10/2014) spec 8.5.3.3.4.2: Max(2, 14 - BitDepth).
   // The Max() was added with the Range Extensions in v2 to handle BitDepth up to 16;
@@ -174,8 +175,8 @@ void put_unweighted_pred_16_fallback(uint16_t *dst, ptrdiff_t dststride,
   assert((width&1)==0);
 
   for (int y=0;y<height;y++) {
-    const int16_t* in  = &src[y*srcstride];
-    uint16_t* out = &dst[y*dststride];
+    const inter_t* in  = &src[y*srcstride];
+    pixel_t* out = &dst[y*dststride];
 
     for (int x=0;x<width;x+=2) {
       out[0] = Clip_BitDepth((in[0] + offset1)>>shift1, bit_depth);
@@ -185,20 +186,23 @@ void put_unweighted_pred_16_fallback(uint16_t *dst, ptrdiff_t dststride,
   }
 }
 
+
+
 #include <stdlib.h>
 
-void put_weighted_pred_16_fallback(uint16_t *dst, ptrdiff_t dststride,
-                                   const int16_t *src, ptrdiff_t srcstride,
-                                   int width, int height,
-                                   int w,int o,int log2WD, int bit_depth)
+template <class pixel_t, class inter_t>
+void put_weighted_pred_fallback(pixel_t *dst, ptrdiff_t dststride,
+                                  const inter_t *src, ptrdiff_t srcstride,
+                                  int width, int height,
+                                  int w,int o,int log2WD, int bit_depth)
 {
   assert(log2WD>=1); // TODO
 
   const int rnd = (1<<(log2WD-1));
 
   for (int y=0;y<height;y++) {
-    const int16_t* in  = &src[y*srcstride];
-    uint16_t* out = &dst[y*dststride];
+    const inter_t* in  = &src[y*srcstride];
+    pixel_t* out = &dst[y*dststride];
 
     for (int x=0;x<width;x++) {
       out[0] = Clip_BitDepth(((in[0]*w + rnd)>>log2WD) + o, bit_depth);
@@ -207,19 +211,22 @@ void put_weighted_pred_16_fallback(uint16_t *dst, ptrdiff_t dststride,
   }
 }
 
-void put_weighted_bipred_16_fallback(uint16_t *dst, ptrdiff_t dststride,
-                                     const int16_t *src1, const int16_t *src2, ptrdiff_t srcstride,
-                                     int width, int height,
-                                     int w1,int o1, int w2,int o2, int log2WD, int bit_depth)
+
+
+template <class pixel_t, class inter_t>
+void put_weighted_bipred_fallback(pixel_t *dst, ptrdiff_t dststride,
+                                    const inter_t *src1, const inter_t *src2, ptrdiff_t srcstride,
+                                    int width, int height,
+                                    int w1,int o1, int w2,int o2, int log2WD, int bit_depth)
 {
   assert(log2WD>=1); // TODO
 
   const int rnd = static_cast<int>(static_cast<unsigned int>(o1+o2+1) << log2WD);
 
   for (int y=0;y<height;y++) {
-    const int16_t* in1 = &src1[y*srcstride];
-    const int16_t* in2 = &src2[y*srcstride];
-    uint16_t* out = &dst[y*dststride];
+    const inter_t* in1 = &src1[y*srcstride];
+    const inter_t* in2 = &src2[y*srcstride];
+    pixel_t* out = &dst[y*dststride];
 
     for (int x=0;x<width;x++) {
       out[0] = Clip_BitDepth((in1[0]*w1 + in2[0]*w2 + rnd)>>(log2WD+1), bit_depth);
@@ -229,10 +236,13 @@ void put_weighted_bipred_16_fallback(uint16_t *dst, ptrdiff_t dststride,
 }
 
 
-void put_weighted_pred_avg_16_fallback(uint16_t *dst, ptrdiff_t dststride,
-                                       const int16_t *src1, const int16_t *src2,
-                                       ptrdiff_t srcstride, int width,
-                                       int height, int bit_depth)
+
+
+template <class pixel_t, class inter_t>
+void put_weighted_pred_avg_fallback(pixel_t *dst, ptrdiff_t dststride,
+                                      const inter_t *src1, const inter_t *src2,
+                                      ptrdiff_t srcstride, int width,
+                                      int height, int bit_depth)
 {
   // shift2 per HEVC v2 (10/2014) spec 8.5.3.3.4.2: Max(3, 15 - BitDepth).
   // The Max() was added with the Range Extensions in v2 to handle BitDepth up to 16;
@@ -243,9 +253,9 @@ void put_weighted_pred_avg_16_fallback(uint16_t *dst, ptrdiff_t dststride,
   assert((width&1)==0);
 
   for (int y=0;y<height;y++) {
-    const int16_t* in1 = &src1[y*srcstride];
-    const int16_t* in2 = &src2[y*srcstride];
-    uint16_t* out = &dst[y*dststride];
+    const inter_t* in1 = &src1[y*srcstride];
+    const inter_t* in2 = &src2[y*srcstride];
+    pixel_t* out = &dst[y*dststride];
 
     for (int x=0;x<width;x+=2) {
       out[0] = Clip_BitDepth((in1[0] + in2[0] + offset2)>>shift2, bit_depth);
@@ -254,6 +264,19 @@ void put_weighted_pred_avg_16_fallback(uint16_t *dst, ptrdiff_t dststride,
     }
   }
 }
+
+#define INSTANTIATE_WEIGHTED_PRED(pixel_t, inter_t) \
+  template void put_unweighted_pred_fallback<pixel_t,inter_t>(pixel_t*, ptrdiff_t, const inter_t*, ptrdiff_t, int, int, int); \
+  template void put_weighted_pred_fallback<pixel_t,inter_t>(pixel_t*, ptrdiff_t, const inter_t*, ptrdiff_t, int, int, int, int, int, int); \
+  template void put_weighted_bipred_fallback<pixel_t,inter_t>(pixel_t*, ptrdiff_t, const inter_t*, const inter_t*, ptrdiff_t, int, int, int, int, int, int, int, int); \
+  template void put_weighted_pred_avg_fallback<pixel_t,inter_t>(pixel_t*, ptrdiff_t, const inter_t*, const inter_t*, ptrdiff_t, int, int, int);
+
+INSTANTIATE_WEIGHTED_PRED(uint16_t, int16_t)  // the acceleration table's _16 entries
+INSTANTIATE_WEIGHTED_PRED(uint8_t,  int32_t)
+INSTANTIATE_WEIGHTED_PRED(uint16_t, int32_t)
+#undef INSTANTIATE_WEIGHTED_PRED
+
+
 
 
 
@@ -279,19 +302,20 @@ void put_epel_8_fallback(int16_t *out, ptrdiff_t out_stride,
 }
 
 
-void put_epel_16_fallback(int16_t *out, ptrdiff_t out_stride,
-                          const uint16_t *src, ptrdiff_t src_stride,
-                          int width, int height,
-                          int mx, int my, int16_t* mcbuffer, int bit_depth)
+// full-sample position (8.5.3.3.3.2 / 8.5.3.3.3.3): predSample = ref << shift3
+template <class pixel_t, class inter_t>
+static void put_fullpel_fallback(inter_t *out, ptrdiff_t out_stride,
+                                 const pixel_t *src, ptrdiff_t src_stride,
+                                 int width, int height, int bit_depth)
 {
-  // shift3 per HEVC v2 (10/2014) spec 8.5.3.3.3.3 (chroma): Max(2, 14 - BitDepth).
+  // shift3 per HEVC v2 (10/2014) spec: Max(2, 14 - BitDepth).
   // The Max() was added with the Range Extensions in v2 to handle BitDepth up to 16;
   // the v1 (04/2013) formula was just (14 - BitDepth), valid only for BitDepth <= 14.
   int shift3 = std::max(2, 14 - bit_depth);
 
   for (int y=0;y<height;y++) {
-    int16_t* o = &out[y*out_stride];
-    const uint16_t* i = &src[y*src_stride];
+    inter_t* o = &out[y*out_stride];
+    const pixel_t* i = &src[y*src_stride];
 
     for (int x=0;x<width;x++) {
       *o = *i << shift3;
@@ -301,14 +325,36 @@ void put_epel_16_fallback(int16_t *out, ptrdiff_t out_stride,
   }
 }
 
+void put_epel_16_fallback(int16_t *out, ptrdiff_t out_stride,
+                          const uint16_t *src, ptrdiff_t src_stride,
+                          int width, int height,
+                          int mx, int my, int16_t* mcbuffer, int bit_depth)
+{
+  put_fullpel_fallback(out,out_stride, src,src_stride, width,height, bit_depth);
+}
 
 template <class pixel_t>
-void put_epel_hv_fallback(int16_t *dst, ptrdiff_t dst_stride,
+void put_epel_32_fallback(int32_t *out, ptrdiff_t out_stride,
+                          const pixel_t *src, ptrdiff_t src_stride,
+                          int width, int height, int bit_depth)
+{
+  put_fullpel_fallback(out,out_stride, src,src_stride, width,height, bit_depth);
+}
+
+template void put_epel_32_fallback<uint8_t> (int32_t*, ptrdiff_t, const uint8_t*,  ptrdiff_t, int, int, int);
+template void put_epel_32_fallback<uint16_t>(int32_t*, ptrdiff_t, const uint16_t*, ptrdiff_t, int, int, int);
+
+
+template <class pixel_t, class inter_t>
+void put_epel_hv_fallback(inter_t *dst, ptrdiff_t dst_stride,
                           const pixel_t *src, ptrdiff_t src_stride,
                           int nPbWC, int nPbHC,
-                          int xFracC, int yFracC, int16_t* mcbuffer, int bit_depth)
+                          int xFracC, int yFracC, inter_t* mcbuffer, int bit_depth)
 {
-  const int shift1 = bit_depth-8;
+  // shift1 per HEVC v2 (10/2014) spec 8.5.3.3.3.3: Min(4, BitDepth - 8).
+  // The Min() was added with the Range Extensions in v2; the v1 (04/2013)
+  // formula was just (BitDepth - 8). See MC_MAX_BIT_DEPTH_INT16 for inter_t.
+  const int shift1 = std::min(4, bit_depth-8);
   const int shift2 = 6;
   //const int shift3 = 6;
 
@@ -320,7 +366,7 @@ void put_epel_hv_fallback(int16_t *dst, ptrdiff_t dst_stride,
 
   int nPbH_extra = extra_top  + nPbHC + extra_bottom;
 
-  int16_t* tmp2buf = (int16_t*)alloca( nPbWC      * nPbH_extra * sizeof(int16_t) );
+  inter_t* tmp2buf = (inter_t*)alloca( nPbWC      * nPbH_extra * sizeof(inter_t) );
 
   /*
   int nPbW_extra = extra_left + nPbWC + extra_right;
@@ -351,7 +397,7 @@ void put_epel_hv_fallback(int16_t *dst, ptrdiff_t dst_stride,
     const pixel_t* p = &src[y*src_stride - extra_left];
 
     for (int x=0;x<nPbWC;x++) {
-      int16_t v;
+      inter_t v;
       switch (xFracC) {
       case 0: v = p[1]; break;
       case 1: v = (-2*p[0]+58*p[1]+10*p[2]-2*p[3])>>shift1; break;
@@ -379,10 +425,10 @@ void put_epel_hv_fallback(int16_t *dst, ptrdiff_t dst_stride,
   int vshift = (xFracC==0 ? shift1 : shift2);
 
   for (int x=0;x<nPbWC;x++) {
-    int16_t* p = &tmp2buf[x*nPbH_extra];
+    inter_t* p = &tmp2buf[x*nPbH_extra];
 
     for (int y=0;y<nPbHC;y++) {
-      int16_t v;
+      inter_t v;
       //logtrace(LogMotion,"%x %x %x  %x  %x %x %x\n",p[0],p[1],p[2],p[3],p[4],p[5],p[6]);
 
       switch (yFracC) {
@@ -415,16 +461,10 @@ void put_epel_hv_fallback(int16_t *dst, ptrdiff_t dst_stride,
 }
 
 
-template
-void put_epel_hv_fallback<uint8_t>(int16_t *dst, ptrdiff_t dst_stride,
-                                   const uint8_t *src, ptrdiff_t src_stride,
-                                   int nPbWC, int nPbHC,
-                                   int xFracC, int yFracC, int16_t* mcbuffer, int bit_depth);
-template
-void put_epel_hv_fallback<uint16_t>(int16_t *dst, ptrdiff_t dst_stride,
-                                    const uint16_t *src, ptrdiff_t src_stride,
-                                    int nPbWC, int nPbHC,
-                                    int xFracC, int yFracC, int16_t* mcbuffer, int bit_depth);
+template void put_epel_hv_fallback<uint8_t, int16_t>(int16_t*, ptrdiff_t, const uint8_t*,  ptrdiff_t, int, int, int, int, int16_t*, int);
+template void put_epel_hv_fallback<uint16_t,int16_t>(int16_t*, ptrdiff_t, const uint16_t*, ptrdiff_t, int, int, int, int, int16_t*, int);
+template void put_epel_hv_fallback<uint8_t, int32_t>(int32_t*, ptrdiff_t, const uint8_t*,  ptrdiff_t, int, int, int, int, int32_t*, int);
+template void put_epel_hv_fallback<uint16_t,int32_t>(int32_t*, ptrdiff_t, const uint16_t*, ptrdiff_t, int, int, int, int, int32_t*, int);
 
 
 
@@ -465,23 +505,7 @@ void put_qpel_0_0_fallback_16(int16_t *out, ptrdiff_t out_stride,
                               const uint16_t *src, ptrdiff_t srcstride,
                               int nPbW, int nPbH, int16_t* mcbuffer, int bit_depth)
 {
-  //const int shift1 = bit_depth-8;
-  //const int shift2 = 6;
-  // shift3 per HEVC v2 (10/2014) spec 8.5.3.3.3.2 (luma): Max(2, 14 - BitDepth).
-  // The Max() was added with the Range Extensions in v2 to handle BitDepth up to 16;
-  // the v1 (04/2013) formula was just (14 - BitDepth), valid only for BitDepth <= 14.
-  const int shift3 = std::max(2, 14-bit_depth);
-
-  // straight copy
-
-  for (int y=0;y<nPbH;y++) {
-    const uint16_t* p = src + srcstride*y;
-    int16_t* o = out + out_stride*y;
-
-    for (int x=0;x<nPbW;x++) {
-      *o++ = *p++ << shift3;
-    }
-  }
+  put_fullpel_fallback(out,out_stride, src,srcstride, nPbW,nPbH, bit_depth);
 }
 
 
@@ -489,11 +513,11 @@ void put_qpel_0_0_fallback_16(int16_t *out, ptrdiff_t out_stride,
 static int extra_before[4] = { 0,3,3,2 };
 static int extra_after [4] = { 0,3,4,4 };
 
-template <class pixel_t>
-void put_qpel_fallback(int16_t *out, ptrdiff_t out_stride,
-                       const pixel_t *src, ptrdiff_t srcstride,
-                       int nPbW, int nPbH, int16_t* mcbuffer,
-                       int xFracL, int yFracL, int bit_depth)
+template <class pixel_t, class inter_t>
+static void put_qpel_fallback(inter_t *out, ptrdiff_t out_stride,
+                              const pixel_t *src, ptrdiff_t srcstride,
+                              int nPbW, int nPbH, inter_t* mcbuffer,
+                              int xFracL, int yFracL, int bit_depth)
 {
   int extra_left   = extra_before[xFracL];
   //int extra_right  = extra_after [xFracL];
@@ -503,7 +527,10 @@ void put_qpel_fallback(int16_t *out, ptrdiff_t out_stride,
   //int nPbW_extra = extra_left + nPbW + extra_right;
   int nPbH_extra = extra_top  + nPbH + extra_bottom;
 
-  const int shift1 = bit_depth-8;
+  // shift1 per HEVC v2 (10/2014) spec 8.5.3.3.3.2: Min(4, BitDepth - 8).
+  // The Min() was added with the Range Extensions in v2; the v1 (04/2013)
+  // formula was just (BitDepth - 8). See MC_MAX_BIT_DEPTH_INT16 for inter_t.
+  const int shift1 = std::min(4, bit_depth-8);
   const int shift2 = 6;
 
 
@@ -513,7 +540,7 @@ void put_qpel_fallback(int16_t *out, ptrdiff_t out_stride,
   case 0:
     for (int y=-extra_top;y<nPbH+extra_bottom;y++) {
       const pixel_t* p = src + srcstride*y - extra_left;
-      int16_t* o = &mcbuffer[y+extra_top];
+      inter_t* o = &mcbuffer[y+extra_top];
 
       for (int x=0;x<nPbW;x++) {
         *o = *p;
@@ -525,7 +552,7 @@ void put_qpel_fallback(int16_t *out, ptrdiff_t out_stride,
   case 1:
     for (int y=-extra_top;y<nPbH+extra_bottom;y++) {
       const pixel_t* p = src + srcstride*y - extra_left;
-      int16_t* o = &mcbuffer[y+extra_top];
+      inter_t* o = &mcbuffer[y+extra_top];
 
       for (int x=0;x<nPbW;x++) {
         *o = (-p[0]+4*p[1]-10*p[2]+58*p[3]+17*p[4] -5*p[5]  +p[6])>>shift1;
@@ -537,7 +564,7 @@ void put_qpel_fallback(int16_t *out, ptrdiff_t out_stride,
   case 2:
     for (int y=-extra_top;y<nPbH+extra_bottom;y++) {
       const pixel_t* p = src + srcstride*y - extra_left;
-      int16_t* o = &mcbuffer[y+extra_top];
+      inter_t* o = &mcbuffer[y+extra_top];
 
       for (int x=0;x<nPbW;x++) {
         *o = (-p[0]+4*p[1]-11*p[2]+40*p[3]+40*p[4]-11*p[5]+4*p[6]-p[7])>>shift1;
@@ -549,7 +576,7 @@ void put_qpel_fallback(int16_t *out, ptrdiff_t out_stride,
   case 3:
     for (int y=-extra_top;y<nPbH+extra_bottom;y++) {
       const pixel_t* p = src + srcstride*y - extra_left;
-      int16_t* o = &mcbuffer[y+extra_top];
+      inter_t* o = &mcbuffer[y+extra_top];
 
       for (int x=0;x<nPbW;x++) {
         *o = ( p[0]-5*p[1]+17*p[2]+58*p[3]-10*p[4] +4*p[5]  -p[6])>>shift1;
@@ -577,8 +604,8 @@ void put_qpel_fallback(int16_t *out, ptrdiff_t out_stride,
   switch (yFracL) {
   case 0:
     for (int x=0;x<nPbW;x++) {
-      const int16_t* p = &mcbuffer[x*nPbH_extra];
-      int16_t* o = &out[x];
+      const inter_t* p = &mcbuffer[x*nPbH_extra];
+      inter_t* o = &out[x];
 
       for (int y=0;y<nPbH;y++) {
         *o = *p;
@@ -589,8 +616,8 @@ void put_qpel_fallback(int16_t *out, ptrdiff_t out_stride,
     break;
   case 1:
     for (int x=0;x<nPbW;x++) {
-      const int16_t* p = &mcbuffer[x*nPbH_extra];
-      int16_t* o = &out[x];
+      const inter_t* p = &mcbuffer[x*nPbH_extra];
+      inter_t* o = &out[x];
 
       for (int y=0;y<nPbH;y++) {
         *o = (-p[0]+4*p[1]-10*p[2]+58*p[3]+17*p[4] -5*p[5]  +p[6])>>vshift;
@@ -601,8 +628,8 @@ void put_qpel_fallback(int16_t *out, ptrdiff_t out_stride,
     break;
   case 2:
     for (int x=0;x<nPbW;x++) {
-      const int16_t* p = &mcbuffer[x*nPbH_extra];
-      int16_t* o = &out[x];
+      const inter_t* p = &mcbuffer[x*nPbH_extra];
+      inter_t* o = &out[x];
 
       for (int y=0;y<nPbH;y++) {
         *o = (-p[0]+4*p[1]-11*p[2]+40*p[3]+40*p[4]-11*p[5]+4*p[6]-p[7])>>vshift;
@@ -613,8 +640,8 @@ void put_qpel_fallback(int16_t *out, ptrdiff_t out_stride,
     break;
   case 3:
     for (int x=0;x<nPbW;x++) {
-      const int16_t* p = &mcbuffer[x*nPbH_extra];
-      int16_t* o = &out[x];
+      const inter_t* p = &mcbuffer[x*nPbH_extra];
+      inter_t* o = &out[x];
 
       for (int y=0;y<nPbH;y++) {
         *o = ( p[0]-5*p[1]+17*p[2]+58*p[3]-10*p[4] +4*p[5]  -p[6])>>vshift;
@@ -657,3 +684,21 @@ QPEL(3,0) QPEL(3,1) QPEL(3,2) QPEL(3,3)
 QPEL16(1,0) QPEL16(1,1) QPEL16(1,2) QPEL16(1,3)
 QPEL16(2,0) QPEL16(2,1) QPEL16(2,2) QPEL16(2,3)
 QPEL16(3,0) QPEL16(3,1) QPEL16(3,2) QPEL16(3,3)
+
+
+template <class pixel_t>
+void put_qpel_32_fallback(int32_t *out, ptrdiff_t out_stride,
+                          const pixel_t *src, ptrdiff_t srcstride,
+                          int nPbW, int nPbH, int32_t* mcbuffer,
+                          int xFracL, int yFracL, int bit_depth)
+{
+  if (xFracL==0 && yFracL==0) {
+    put_fullpel_fallback(out,out_stride, src,srcstride, nPbW,nPbH, bit_depth);
+  }
+  else {
+    put_qpel_fallback(out,out_stride, src,srcstride, nPbW,nPbH,mcbuffer, xFracL,yFracL, bit_depth);
+  }
+}
+
+template void put_qpel_32_fallback<uint8_t> (int32_t*, ptrdiff_t, const uint8_t*,  ptrdiff_t, int, int, int32_t*, int, int, int);
+template void put_qpel_32_fallback<uint16_t>(int32_t*, ptrdiff_t, const uint16_t*, ptrdiff_t, int, int, int32_t*, int, int, int);

--- a/libde265/fallback-motion.h
+++ b/libde265/fallback-motion.h
@@ -25,6 +25,14 @@
 #include <stdint.h>
 
 
+/* The interpolated prediction samples (predSamplesLX in 8.5.3.3.3) are kept
+   in int16_t up to this bit depth. Above it, shift1 = Min(4, BitDepth-8) of
+   (8.5.3.3.3.2) and (8.5.3.3.3.3) stops growing with the bit depth, so the
+   intermediates need up to 20 bits and the int32_t variants below are used.
+ */
+const int MC_MAX_BIT_DEPTH_INT16 = 12;
+
+
 void put_weighted_pred_avg_8_fallback(uint8_t *dst, ptrdiff_t dststride,
                                       const int16_t *src1, const int16_t *src2,
                                       ptrdiff_t srcstride, int width,
@@ -43,23 +51,29 @@ void put_weighted_bipred_8_fallback(uint8_t *_dst, ptrdiff_t dststride,
                                     int width, int height,
                                     int w1,int o1, int w2,int o2, int log2WD);
 
-void put_weighted_pred_avg_16_fallback(uint16_t *dst, ptrdiff_t dststride,
-                                       const int16_t *src1, const int16_t *src2,
-                                       ptrdiff_t srcstride, int width,
-                                       int height, int bit_depth);
+// pixel_t is uint8_t or uint16_t, inter_t is int16_t or int32_t (see MC_MAX_BIT_DEPTH_INT16)
 
-void put_unweighted_pred_16_fallback(uint16_t *_dst, ptrdiff_t dststride,
-                                     const int16_t *src, ptrdiff_t srcstride,
-                                     int width, int height, int bit_depth);
+template <class pixel_t, class inter_t>
+void put_weighted_pred_avg_fallback(pixel_t *dst, ptrdiff_t dststride,
+                                    const inter_t *src1, const inter_t *src2,
+                                    ptrdiff_t srcstride, int width,
+                                    int height, int bit_depth);
 
-void put_weighted_pred_16_fallback(uint16_t *_dst, ptrdiff_t dststride,
-                                   const int16_t *src, ptrdiff_t srcstride,
-                                   int width, int height,
-                                   int w,int o,int log2WD, int bit_depth);
-void put_weighted_bipred_16_fallback(uint16_t *_dst, ptrdiff_t dststride,
-                                     const int16_t *src1, const int16_t *src2, ptrdiff_t srcstride,
-                                     int width, int height,
-                                     int w1,int o1, int w2,int o2, int log2WD, int bit_depth);
+template <class pixel_t, class inter_t>
+void put_unweighted_pred_fallback(pixel_t *_dst, ptrdiff_t dststride,
+                                  const inter_t *src, ptrdiff_t srcstride,
+                                  int width, int height, int bit_depth);
+
+template <class pixel_t, class inter_t>
+void put_weighted_pred_fallback(pixel_t *_dst, ptrdiff_t dststride,
+                                const inter_t *src, ptrdiff_t srcstride,
+                                int width, int height,
+                                int w,int o,int log2WD, int bit_depth);
+template <class pixel_t, class inter_t>
+void put_weighted_bipred_fallback(pixel_t *_dst, ptrdiff_t dststride,
+                                  const inter_t *src1, const inter_t *src2, ptrdiff_t srcstride,
+                                  int width, int height,
+                                  int w1,int o1, int w2,int o2, int log2WD, int bit_depth);
 
 
 
@@ -73,11 +87,11 @@ void put_epel_16_fallback(int16_t *out, ptrdiff_t out_stride,
                           int width, int height,
                           int mx, int my, int16_t* mcbuffer, int bit_depth);
 
-template <class pixel_t>
-void put_epel_hv_fallback(int16_t *dst, ptrdiff_t dststride,
+template <class pixel_t, class inter_t = int16_t>
+void put_epel_hv_fallback(inter_t *dst, ptrdiff_t dststride,
                           const pixel_t *_src, ptrdiff_t srcstride,
                           int width, int height,
-                          int mx, int my, int16_t* mcbuffer, int bit_depth);
+                          int mx, int my, inter_t* mcbuffer, int bit_depth);
 
 
 #define QPEL(x,y) void put_qpel_ ## x ## _ ## y ## _fallback(int16_t *out, ptrdiff_t out_stride, \
@@ -100,5 +114,25 @@ QPEL(2,0); QPEL(2,1); QPEL(2,2); QPEL(2,3);
 QPEL(3,0); QPEL(3,1); QPEL(3,2); QPEL(3,3);
 
 #undef QPEL
+
+
+/* Interpolation with int32_t intermediates for bit depths above
+   MC_MAX_BIT_DEPTH_INT16. There is no acceleration table for these; they
+   are reached through the int32_t overloads in acceleration_functions.
+   pixel_t is uint8_t or uint16_t, since luma and chroma bit depths are
+   independent.
+ */
+
+template <class pixel_t>
+void put_epel_32_fallback(int32_t *out, ptrdiff_t out_stride,
+                          const pixel_t *src, ptrdiff_t src_stride,
+                          int width, int height, int bit_depth);
+
+// all fractional positions, including full-pel (xFracL==0 && yFracL==0)
+template <class pixel_t>
+void put_qpel_32_fallback(int32_t *out, ptrdiff_t out_stride,
+                          const pixel_t *src, ptrdiff_t srcstride,
+                          int nPbW, int nPbH, int32_t* mcbuffer,
+                          int xFracL, int yFracL, int bit_depth);
 
 #endif

--- a/libde265/fallback.cc
+++ b/libde265/fallback.cc
@@ -32,10 +32,10 @@ void init_acceleration_functions_fallback(struct acceleration_functions* accel)
   accel->put_weighted_pred_8 = put_weighted_pred_8_fallback;
   accel->put_weighted_bipred_8 = put_weighted_bipred_8_fallback;
 
-  accel->put_weighted_pred_avg_16 = put_weighted_pred_avg_16_fallback;
-  accel->put_unweighted_pred_16   = put_unweighted_pred_16_fallback;
-  accel->put_weighted_pred_16 = put_weighted_pred_16_fallback;
-  accel->put_weighted_bipred_16 = put_weighted_bipred_16_fallback;
+  accel->put_weighted_pred_avg_16 = put_weighted_pred_avg_fallback<uint16_t,int16_t>;
+  accel->put_unweighted_pred_16   = put_unweighted_pred_fallback<uint16_t,int16_t>;
+  accel->put_weighted_pred_16 = put_weighted_pred_fallback<uint16_t,int16_t>;
+  accel->put_weighted_bipred_16 = put_weighted_bipred_fallback<uint16_t,int16_t>;
 
 
   accel->put_hevc_epel_8    = put_epel_8_fallback;

--- a/libde265/motion.cc
+++ b/libde265/motion.cc
@@ -24,6 +24,7 @@
 #include "dpb.h"
 
 #include <assert.h>
+#include <memory>
 
 
 #include <sys/types.h>
@@ -44,12 +45,40 @@ static int extra_before[4] = { 0,3,3,2 };
 static int extra_after [4] = { 0,3,4,4 };
 
 
+/* Prediction samples of one PB (predSamplesL0/L1 of 8.5.3.3.4).
+   With int16_t they live on the stack. The int32_t set for bit depths above
+   MC_MAX_BIT_DEPTH_INT16 is twice as large (96 KB), which is more than some
+   default thread stacks allow for, so it is kept in per-thread storage.
+ */
+template <class inter_t> struct pred_samples
+{
+  ALIGNED_16(inter_t) L                 [2 /* LX */][MAX_CU_SIZE* MAX_CU_SIZE];
+  ALIGNED_16(inter_t) C[2 /* chroma */ ][2 /* LX */][MAX_CU_SIZE* MAX_CU_SIZE];
+};
 
-template <class pixel_t>
+template <class inter_t> struct pred_samples_storage
+{
+  pred_samples<inter_t> samples;
+  pred_samples<inter_t>& get() { return samples; }
+};
+
+template <> struct pred_samples_storage<int32_t>
+{
+  pred_samples<int32_t>& get()
+  {
+    static thread_local std::unique_ptr<pred_samples<int32_t> > samples;
+    if (!samples) { samples.reset(new pred_samples<int32_t>); }
+    return *samples;
+  }
+};
+
+
+
+template <class pixel_t, class inter_t>
 void mc_luma(const base_context* ctx,
              const seq_parameter_set* sps, int mv_x, int mv_y,
              int xP,int yP,
-             int16_t* out, int out_stride,
+             inter_t* out, int out_stride,
              const pixel_t* ref, ptrdiff_t ref_stride,
              int nPbW, int nPbH, int bitDepth_L)
 {
@@ -68,7 +97,7 @@ void mc_luma(const base_context* ctx,
   int w = sps->pic_width_in_luma_samples;
   int h = sps->pic_height_in_luma_samples;
 
-  ALIGNED_16(int16_t) mcbuffer[MAX_CU_SIZE * (MAX_CU_SIZE+7)];
+  ALIGNED_16(inter_t) mcbuffer[MAX_CU_SIZE * (MAX_CU_SIZE+7)];
 
   if (xFracL==0 && yFracL==0) {
 
@@ -175,12 +204,12 @@ void mc_luma(const base_context* ctx,
 
 
 
-template <class pixel_t>
+template <class pixel_t, class inter_t>
 void mc_chroma(const base_context* ctx,
                const seq_parameter_set* sps,
                int mv_x, int mv_y,
                int xP,int yP,
-               int16_t* out, int out_stride,
+               inter_t* out, int out_stride,
                const pixel_t* ref, ptrdiff_t ref_stride,
                int nPbWC, int nPbHC, int bit_depth_C)
 {
@@ -202,7 +231,7 @@ void mc_chroma(const base_context* ctx,
   int xIntOffsC = xP/sps->SubWidthC  + (mv_x>>3);
   int yIntOffsC = yP/sps->SubHeightC + (mv_y>>3);
 
-  ALIGNED_32(int16_t mcbuffer[MAX_CU_SIZE*(MAX_CU_SIZE+7)]);
+  ALIGNED_32(inter_t mcbuffer[MAX_CU_SIZE*(MAX_CU_SIZE+7)]);
 
   if (xFracC == 0 && yFracC == 0) {
     if (xIntOffsC>=0 && nPbWC+xIntOffsC<=wC &&
@@ -285,13 +314,15 @@ void mc_chroma(const base_context* ctx,
 
 // 8.5.3.2
 // NOTE: for full-pel shifts, we can introduce a fast path, simply copying without shifts
-void generate_inter_prediction_samples(base_context* ctx,
-                                       const slice_segment_header* shdr,
-                                       de265_image* img,
-                                       int xC,int yC,
-                                       int xB,int yB,
-                                       int nCS, int nPbW,int nPbH,
-                                       const PBMotion* vi)
+// inter_t is the type of the prediction samples (see MC_MAX_BIT_DEPTH_INT16).
+template <class inter_t>
+static void generate_inter_prediction_samples_impl(base_context* ctx,
+                                                   const slice_segment_header* shdr,
+                                                   de265_image* img,
+                                                   int xC,int yC,
+                                                   int xB,int yB,
+                                                   int nCS, int nPbW,int nPbH,
+                                                   const PBMotion* vi)
 {
   int xP = xC+xB;
   int yP = yC+yB;
@@ -328,8 +359,9 @@ void generate_inter_prediction_samples(base_context* ctx,
   stride[2] = img->get_image_stride(2);
 
 
-  ALIGNED_16(int16_t) predSamplesL                 [2 /* LX */][MAX_CU_SIZE* MAX_CU_SIZE];
-  ALIGNED_16(int16_t) predSamplesC[2 /* chroma */ ][2 /* LX */][MAX_CU_SIZE* MAX_CU_SIZE];
+  pred_samples_storage<inter_t> storage;
+  auto& predSamplesL = storage.get().L;
+  auto& predSamplesC = storage.get().C;
 
   //int xP = xC+xB;
   //int yP = yC+yB;
@@ -360,17 +392,19 @@ void generate_inter_prediction_samples(base_context* ctx,
   // Fill prediction samples with mid-grey in intermediate precision.
   // Used on error paths where the reference picture is unavailable or mismatched.
   auto fill_pred_samples = [&](int l) {
-    const int16_t fill = 1 << 13; // mid-grey: (1 << (bd-1)) << (14-bd) for any bd
+    // mid-grey, i.e. (1 << (bd-1)) << shift3 with shift3 = Max(2, 14-bd) (8.5.3.3.3)
+    const inter_t fillL = (1 << (bit_depth_L-1)) << std::max(2, 14-bit_depth_L);
+    const inter_t fillC = (1 << (bit_depth_C-1)) << std::max(2, 14-bit_depth_C);
     for (int y = 0; y < nPbH; y++)
       for (int x = 0; x < nPbW; x++)
-        predSamplesL[l][y * nCS + x] = fill;
+        predSamplesL[l][y * nCS + x] = fillL;
     if (img->get_chroma_format() != de265_chroma_mono) {
       int cW = nPbW / SubWidthC;
       int cH = nPbH / SubHeightC;
       for (int y = 0; y < cH; y++)
         for (int x = 0; x < cW; x++) {
-          predSamplesC[0][l][y * nCS + x] = fill;
-          predSamplesC[1][l][y * nCS + x] = fill;
+          predSamplesC[0][l][y * nCS + x] = fillC;
+          predSamplesC[1][l][y * nCS + x] = fillC;
         }
     }
   };
@@ -556,16 +590,16 @@ void generate_inter_prediction_samples(base_context* ctx,
         //const int shift2  = 15-8; // TODO: real bit depth
         //const int offset2 = 1<<(shift2-1);
 
-        int16_t* in0 = predSamplesL[0];
-        int16_t* in1 = predSamplesL[1];
+        inter_t* in0 = predSamplesL[0];
+        inter_t* in1 = predSamplesL[1];
 
         ctx->acceleration.put_weighted_pred_avg(pixels[0], stride[0],
                                                 in0,in1, nCS, nPbW, nPbH, bit_depth_L);
 
-        int16_t* in00 = predSamplesC[0][0];
-        int16_t* in01 = predSamplesC[0][1];
-        int16_t* in10 = predSamplesC[1][0];
-        int16_t* in11 = predSamplesC[1][1];
+        inter_t* in00 = predSamplesC[0][0];
+        inter_t* in01 = predSamplesC[0][1];
+        inter_t* in10 = predSamplesC[1][0];
+        inter_t* in11 = predSamplesC[1][1];
 
         if (img->get_chroma_format() != de265_chroma_mono) {
           ctx->acceleration.put_weighted_pred_avg(pixels[1], stride[1],
@@ -602,8 +636,8 @@ void generate_inter_prediction_samples(base_context* ctx,
         logtrace(LogMotion,"weighted-BI-0 [%d] %d %d %d  %dx%d\n", refIdx0, luma_log2WD-6,luma_w0,luma_o0,nPbW,nPbH);
         logtrace(LogMotion,"weighted-BI-1 [%d] %d %d %d  %dx%d\n", refIdx1, luma_log2WD-6,luma_w1,luma_o1,nPbW,nPbH);
 
-        int16_t* in0 = predSamplesL[0];
-        int16_t* in1 = predSamplesL[1];
+        inter_t* in0 = predSamplesL[0];
+        inter_t* in1 = predSamplesL[1];
 
         ctx->acceleration.put_weighted_bipred(pixels[0], stride[0],
                                               in0,in1, nCS, nPbW, nPbH,
@@ -611,10 +645,10 @@ void generate_inter_prediction_samples(base_context* ctx,
                                               luma_w1,luma_o1,
                                               luma_log2WD, bit_depth_L);
 
-        int16_t* in00 = predSamplesC[0][0];
-        int16_t* in01 = predSamplesC[0][1];
-        int16_t* in10 = predSamplesC[1][0];
-        int16_t* in11 = predSamplesC[1][1];
+        inter_t* in00 = predSamplesC[0][0];
+        inter_t* in01 = predSamplesC[0][1];
+        inter_t* in10 = predSamplesC[1][0];
+        inter_t* in11 = predSamplesC[1][1];
 
         if (img->get_chroma_format() != de265_chroma_mono) {
           ctx->acceleration.put_weighted_bipred(pixels[1], stride[1],
@@ -726,6 +760,26 @@ void generate_inter_prediction_samples(base_context* ctx,
     logtrace(LogTransform,"*\n");
   }
 #endif
+}
+
+
+void generate_inter_prediction_samples(base_context* ctx,
+                                       const slice_segment_header* shdr,
+                                       de265_image* img,
+                                       int xC,int yC,
+                                       int xB,int yB,
+                                       int nCS, int nPbW,int nPbH,
+                                       const PBMotion* vi)
+{
+  const seq_parameter_set* sps = shdr->pps->sps.get();
+
+  if (sps->BitDepth_Y > MC_MAX_BIT_DEPTH_INT16 ||
+      sps->BitDepth_C > MC_MAX_BIT_DEPTH_INT16) {
+    generate_inter_prediction_samples_impl<int32_t>(ctx,shdr,img, xC,yC, xB,yB, nCS, nPbW,nPbH, vi);
+  }
+  else {
+    generate_inter_prediction_samples_impl<int16_t>(ctx,shdr,img, xC,yC, xB,yB, nCS, nPbW,nPbH, vi);
+  }
 }
 
 


### PR DESCRIPTION
Follow-up to #538. Intra-only 16-bit streams decode correctly since that fix, but any inter picture above 12 bit was still wrong from the first B/P frame on (essentially every sample off, errors up to the full range). This makes 13–16 bit work with motion compensation too, including weighted prediction and mixed luma/chroma bit depths.

**Cause.** Two things in the sample interpolation break at 13 bit:

- `put_qpel_fallback` and `put_epel_hv_fallback` used `shift1 = BitDepth-8`. The Range Extensions changed (8.5.3.3.3.2)/(8.5.3.3.3.3) to `shift1 = Min(4, BitDepth-8)`; the v1 formula agrees only up to 12 bit.
- With `shift1` capped at 4, the filter intermediates and `predSamplesLX` need up to 20 bits, but the whole MC path was `int16_t` (`mcbuffer`, `predSamplesL/C`, the full-sample `ref << shift3` copies, the weighted-prediction inputs).

**Fix.** Rather than widening everything to 32 bit (which would cost bandwidth for 9–12 bit and change the SIMD signatures), the intermediate type is a template parameter of the fallback functions, chosen once per PB in `generate_inter_prediction_samples()`: `int16_t` through the acceleration table exactly as before up to `MC_MAX_BIT_DEPTH_INT16` (12), `int32_t` above that. The `int32_t` variants are reached through `int32_t` overloads of the existing `acceleration_functions` wrappers, which keep the per-plane 8/16-bit sample split (luma and chroma depths are independent; an 8-bit plane can sit next to a 14-bit one). No table entries are added for them — there is no SIMD for any >8-bit MC on any platform — and the 8–12-bit path compiles to the same code as on master. The 96 KB `int32_t` prediction-sample set lives in per-thread storage so the stack requirement of the common path does not grow. Also fixes the mid-grey error-path fill, which assumed `shift3 == 14-bd`.

**Verification** against HM 18.0 built with `RExt__HIGH_BIT_DEPTH_SUPPORT` (HM's MCTF pre-filter disabled — it corrupts 16-bit sources — and `ExtendedPrecision` off, as libde265 does not implement it). All byte-exact vs the HM decoder unless noted:

| 640×360, 4:2:0 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 |
|---|---|---|---|---|---|---|---|---|---|
| intra | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
| random access (hier. B, GOP 16) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ *(was wrong)* | ✓ *(was wrong)* | ✓ *(was wrong)* | ✓ *(was wrong)* |

Also bit-exact: low delay with weighted bi-prediction at 8/13/16 bit, with and without `high_precision_offsets_enabled_flag`; 16-bit random access with implicit/explicit RDPCM, persistent Rice adaptation and transform-skip context on; mixed luma/chroma depths 8/14, 14/8, 10/13 (master was wrong in whichever plane was >12 bit); `--noaccel`; `testdata/girlshy.h265` identical to master.

4K (Netflix ToddlerFountain 4096×2160, first 43 frames, originally 10-Bit, low delay B, WPP):

| bit depth | 8 | 10 | 12 | 13 | 16 |
|---|---|---|---|---|---|
| this PR vs HM | exact | exact | exact | exact | exact |
| master vs HM | exact | exact | exact | wrong | wrong |
| fps master → PR, 1 thread | 10.0 → 10.1 | 10.3 → 10.2 | 10.9 → 10.9 | 11.0 → 11.0 | (n/a)\* |
| fps master → PR, 8 threads | 62.6 → 62.7 | 60.0 → 58.3 | 63.4 → 62.1 | 59.8 → 59.7 | (n/a)\* |

All within ±3 % run-to-run noise; 13 bit decodes at the same speed as 12 bit. \*master decodes garbage at 16 bit, so its timing is not a baseline; on this PR 16 bit runs at 10.3 / 51.6 fps.

Unrelated things noticed on the way, left for separate issues: `transform_skip_rotation_enabled_flag` gives small chroma-only errors in inter pictures even at 8 bit, and `dec265 -c` only reports a picture-hash mismatch on the last picture (`read_slice_NAL()` discards `decode_some()`'s error).

The code in this PR was created with the help of an LLM.


**Before/After:**

<img width="160" height="90" alt="before" src="https://github.com/user-attachments/assets/43b52939-f11b-4b1c-a863-dae809b5cbe4" />
<img width="160" height="90" alt="after" src="https://github.com/user-attachments/assets/a198e5b1-9911-4545-84fb-3df23486e978" />
